### PR TITLE
Separate Listener for Banner & Interstitial

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,11 @@ AdMob.showInterstitial();
 #### Event Listener
 This following Event Listener can be called in **Interstitial AD**
 ```ts
-addListener(eventName: 'onAdLoaded', listenerFunc: (info: any) => void): PluginListenerHandle;
-addListener(eventName: 'onAdFailedToLoad', listenerFunc: (info: any) => void): PluginListenerHandle;
-addListener(eventName: 'onAdOpened', listenerFunc: (info: any) => void): PluginListenerHandle;
-addListener(eventName: 'onAdClosed', listenerFunc: (info: any) => void): PluginListenerHandle;
-addListener(eventName: 'onAdLeftApplication', listenerFunc: (info: any) => void): PluginListenerHandle;
+addListener(eventName: 'onInterstitialAdLoaded', listenerFunc: (info: any) => void): PluginListenerHandle;
+addListener(eventName: 'onInterstitialAdFailedToLoad', listenerFunc: (info: any) => void): PluginListenerHandle;
+addListener(eventName: 'onInterstitialAdOpened', listenerFunc: (info: any) => void): PluginListenerHandle;
+addListener(eventName: 'onInterstitialAdClosed', listenerFunc: (info: any) => void): PluginListenerHandle;
+addListener(eventName: 'onInterstitialAdLeftApplication', listenerFunc: (info: any) => void): PluginListenerHandle;
 ```
 
 

--- a/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
@@ -304,7 +304,7 @@ public class AdMob extends Plugin {
                         @Override
                         public void onAdLoaded() {
                             // Code to be executed when an ad finishes loading.
-                            notifyListeners("onAdLoaded", new JSObject().put("value", true));
+                            notifyListeners("onInterstitialAdLoaded", new JSObject().put("value", true));
                             call.success(new JSObject().put("value", true));
                             super.onAdLoaded();
 
@@ -313,28 +313,28 @@ public class AdMob extends Plugin {
                         @Override
                         public void onAdFailedToLoad(int errorCode) {
                             // Code to be executed when an ad request fails.
-                            notifyListeners("onAdFailedToLoad", new JSObject().put("errorCode", errorCode));
+                            notifyListeners("onInterstitialAdFailedToLoad", new JSObject().put("errorCode", errorCode));
                             super.onAdFailedToLoad(errorCode);
                         }
 
                         @Override
                         public void onAdOpened() {
                             // Code to be executed when the ad is displayed.
-                            notifyListeners("onAdOpened", new JSObject().put("value", true));
+                            notifyListeners("onInterstitialAdOpened", new JSObject().put("value", true));
                             super.onAdOpened();
                         }
 
                         @Override
                         public void onAdLeftApplication() {
                             // Code to be executed when the user has left the app.
-                            notifyListeners("onAdLeftApplication", new JSObject().put("value", true));
+                            notifyListeners("onInterstitialAdLeftApplication", new JSObject().put("value", true));
                             super.onAdLeftApplication();
                         }
 
                         @Override
                         public void onAdClosed() {
                             // Code to be executed when when the interstitial ad is closed.
-                            notifyListeners("onAdClosed", new JSObject().put("value", true));
+                            notifyListeners("onInterstitialAdClosed", new JSObject().put("value", true));
                             super.onAdClosed();
                         }
                     });

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -280,6 +280,7 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
 
             self.interstitial = DFPInterstitial(adUnitID: adUnitID)
             self.interstitial.load(DFPRequest())
+            self.interstitial.delegate = self
 
             call.success(["value": true])
         }
@@ -303,19 +304,19 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
     /// Tells the delegate an ad request succeeded.
     public func interstitialDidReceiveAd(_ ad: GADInterstitial) {
         NSLog("interstitialDidReceiveAd")
-        self.notifyListeners("onAdLoaded", data: ["value": true])
+        self.notifyListeners("onInterstitialAdLoaded", data: ["value": true])
     }
 
     /// Tells the delegate an ad request failed.
     public func interstitial(_ ad: GADInterstitial, didFailToReceiveAdWithError error: GADRequestError) {
         NSLog("interstitial:didFailToReceiveAdWithError: \(error.localizedDescription)")
-        self.notifyListeners("onAdFailedToLoad", data: ["error": error.localizedDescription])
+        self.notifyListeners("onInterstitialAdFailedToLoad", data: ["error": error.localizedDescription])
     }
 
     /// Tells the delegate that an interstitial will be presented.
     public func interstitialWillPresentScreen(_ ad: GADInterstitial) {
         NSLog("interstitialWillPresentScreen")
-        self.notifyListeners("onAdOpened", data: ["value": true])
+        self.notifyListeners("onInterstitialAdOpened", data: ["value": true])
     }
 
     /// Tells the delegate the interstitial is to be animated off the screen.
@@ -326,14 +327,14 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
     /// Tells the delegate the interstitial had been animated off the screen.
     public func interstitialDidDismissScreen(_ ad: GADInterstitial) {
         NSLog("interstitialDidDismissScreen")
-        self.notifyListeners("onAdClosed", data: ["value": true])
+        self.notifyListeners("onInterstitialAdClosed", data: ["value": true])
     }
 
     /// Tells the delegate that a user click will open another app
     /// (such as the App Store), backgrounding the current app.
     public func interstitialWillLeaveApplication(_ ad: GADInterstitial) {
         NSLog("interstitialWillLeaveApplication")
-        self.notifyListeners("onAdLeftApplication", data: ["value": true])
+        self.notifyListeners("onInterstitialAdLeftApplication", data: ["value": true])
     }
 
 


### PR DESCRIPTION
Banner & Interstitial share the same listener so we can't define specific action for each. 

Also, It solve a bug on iOS where interstitial event are not fired (tested on iOS 14)