### PR TITLE
fix: fix interstitial ad id

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Capacitory community plugin for AdMob.
 | ------------------- | ----------------------------------- | ------------------------------------- | ---------------------------------------------- |
 | Masahiko Sakakibara | [rdlabo](https://github.com/rdlabo) | [@rdlabo](https://twitter.com/rdlabo) | RELATION DESIGN LABO, GENERAL INC. ASSOCIATION |
 
-Mainteinance Status: Actively Maintained
+Maintenance Status: Actively Maintained
 
 ## Demo
 
@@ -102,7 +102,7 @@ Send and array of device Ids in `testingDevices? to use production like ads on y
 
 ### Initialize for @ionic/angular
 
-Open our Ionic app **app.component.ts** file and add this folloing code.
+Open our Ionic app **app.component.ts** file and add this following code.
 
 ```ts
 import { Plugins } from '@capacitor/core';
@@ -212,7 +212,7 @@ export class AdMobComponent {
     // Show Banner Ad
     AdMob.showBanner(this.options);
 
-    // Subscibe Banner Event Listener
+    // Subscribe Banner Event Listener
     AdMob.addListener('onAdLoaded', (info: boolean) => {
       console.log('Banner Ad Loaded');
     });
@@ -281,8 +281,8 @@ export class AppComponent {
     // Prepare interstitial banner
     AdMob.prepareInterstitial(this.options);
 
-    // Subscibe Banner Event Listener
-    AdMob.addListener('onAdLoaded', (info: boolean) => {
+    // Subscribe Banner Event Listener
+    AdMob.addListener('onInterstitialAdLoaded', (info: boolean) => {
       // You can call showInterstitial() here or anytime you want.
       console.log('Interstitial Ad Loaded');
     });
@@ -332,7 +332,7 @@ export class AdMobComponent {
     // Prepare ReWardVideo
     AdMob.prepareRewardVideoAd(this.options);
 
-    // Subscibe ReWardVideo Event Listener
+    // Subscribe ReWardVideo Event Listener
     AdMob.addListener('onRewardedVideoAdLoaded', (info: boolean) => {
       // You can call showRewardVideoAd() here or anytime you want.
       console.log('RewardedVideoAd Loaded');

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -63,10 +63,11 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
      */
     @objc func showBanner(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            var adId = call.getString("adId") ?? "ca-app-pub-3940256099942544/6300978111"
+            let testingID = "ca-app-pub-3940256099942544/6300978111"
+            var adId = call.getString("adId") ?? testingID
             let isTest = call.getBool("isTesting") ?? false
             if isTest {
-                adId = "ca-app-pub-3940256099942544/6300978111"
+                adId = testingID
             }
 
             let adSize = call.getString("adSize") ?? "SMART_BANNER"
@@ -275,10 +276,11 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
      */
     @objc func prepareInterstitial(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            var adUnitID = call.getString("adId") ?? "ca-app-pub-3940256099942544/1033173712"
+            let testingID = "ca-app-pub-3940256099942544/1033173712" 
+            var adUnitID = call.getString("adId") ?? testingID
             let isTest = call.getBool("isTesting") ?? false
             if isTest {
-                adUnitID = "ca-app-pub-3940256099942544/1033173712"
+                adUnitID = testingID
             }
 
             self.interstitial = GADInterstitial(adUnitID: adUnitID)
@@ -346,10 +348,11 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
      */
     @objc func prepareRewardVideoAd(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            var adUnitID: String = call.getString("adId") ?? "ca-app-pub-3940256099942544/1712485313"
+            let testingID = "ca-app-pub-3940256099942544/1712485313"
+            var adUnitID: String = call.getString("adId") ?? testingID
             let isTest = call.getBool("isTesting") ?? false
             if isTest {
-                adUnitID = "ca-app-pub-3940256099942544/1712485313"
+                adUnitID = testingID
             }
 
             self.rewardedAd = GADRewardedAd(adUnitID: adUnitID)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -275,10 +275,10 @@ public class AdMob: CAPPlugin, GADBannerViewDelegate, GADInterstitialDelegate, G
      */
     @objc func prepareInterstitial(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            var adUnitID = call.getString("adId") ?? "ca-app-pub-3940256099942544/4411468910"
+            var adUnitID = call.getString("adId") ?? "ca-app-pub-3940256099942544/1033173712"
             let isTest = call.getBool("isTesting") ?? false
             if isTest {
-                adUnitID = "ca-app-pub-3940256099942544/6300978111"
+                adUnitID = "ca-app-pub-3940256099942544/1033173712"
             }
 
             self.interstitial = GADInterstitial(adUnitID: adUnitID)


### PR DESCRIPTION
The demo ad id for interstitial is using the demo id for banners.
https://developers.google.com/admob/android/test-ads

This will fix this error while using the isTesting: true for interstitial ads.
`Ad unit doesn't match format. <https://support.google.com/admob/answer/9905175#4>`
