### PR TITLE
iOS: migrate to new admob sdk

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,10 +9,10 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'Google-Mobile-Ads-SDK', '>= 7.64.0'
+  pod 'Google-Mobile-Ads-SDK', '~> 8.0.0'
 end
 
 target 'PluginTests' do
   capacitor_pods
-  pod 'Google-Mobile-Ads-SDK', '>= 7.64.0'
+  pod 'Google-Mobile-Ads-SDK', '~> 8.0.0'
 end


### PR DESCRIPTION
The iOS build currently doesn't work because of breaking changes in the admob-sdk.
This PR resolves the breaking changes with reference to the migration guide: https://developers.google.com/admob/ios/migration#v8

This closes #66 