### PR TITLE
Feat: SSV Options for AdMob Rewarded Ads [Capacitor V3]

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/admob/models/AdOptions.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/models/AdOptions.java
@@ -59,6 +59,22 @@ public abstract class AdOptions {
      */
     public final boolean npa;
 
+    /**
+     * The user identifier to be passed to an SSV callback.
+     * 
+     * @see <a href="https://developers.google.com/android/reference/com/google/android/gms/ads/rewarded/ServerSideVerificationOptions#public-string-getuserid">SSV User Identifier</a>
+     * Default is an empty string ("")
+     */
+    public final String userId;
+
+    /**
+     * The custom data to be passed to an SSV callback.
+     * 
+     * @see <a href="https://developers.google.com/android/reference/com/google/android/gms/ads/rewarded/ServerSideVerificationOptions#public-string-getcustomdata">SSV Custom Data</a>
+     * Default is an empty string ("")
+     */
+    public final String customData;
+
     private AdOptions(PluginCall call) {
         /*
          * TODO: Since the Id in the Typescript AdOptions interface is not optional
@@ -72,6 +88,8 @@ public abstract class AdOptions {
         this.position = call.getString("position", "BOTTOM_CENTER");
         this.margin = call.getInt("margin", 0);
         this.npa = call.getBoolean("npa", false);
+        this.userId = call.getString("userId", "");
+        this.customData = call.getString("customData", "");
 
         String sizeString = call.getString("adSize", BannerAdSizeEnum.ADAPTIVE_BANNER.name());
         this.adSize = AdOptions.adSizeStringToAdSizeEnum(sizeString);

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -13,6 +13,7 @@ import com.getcapacitor.community.admob.models.AdOptions;
 import com.getcapacitor.community.admob.models.Executor;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.rewarded.RewardedAd;
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import com.google.android.gms.common.util.BiConsumer;
 
 public class AdRewardExecutor extends Executor {
@@ -39,6 +40,16 @@ public class AdRewardExecutor extends Executor {
                     try {
                         final AdRequest adRequest = RequestHelper.createRequest(adOptions);
                         final String id = AdViewIdHelper.getFinalAdId(adOptions, adRequest, logTag, contextSupplier.get());
+
+                        if (call.getString("userId", "") != "" || call.getString("customData", "") != "") {
+                            final ServerSideVerificationOptions ssvOptions = new ServerSideVerificationOptions.Builder()
+                                    .setUserId(call.getString("userId", ""))
+                                    .setCustomData(call.getString("customData", ""))
+                                    .build();
+
+                            mRewardedAd.setServerSideVerificationOptions(ssvOptions);
+                        }
+
                         RewardedAd.load(
                             contextSupplier.get(),
                             id,

--- a/ios/Plugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Plugin.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/Plugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/Plugin.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/Plugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Plugin/Rewarded/AdRewardExecutor.swift
@@ -22,6 +22,23 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
                 }
 
                 self.rewardedAd = ad
+                
+                if (call.getString("userId") != "" || call.getString("customData") !== "") {
+                    let ssvOptions = GADServerSideVerificationOptions()
+                    
+                    if (call.getString("userId") != "") {
+                        NSLog("Enabling SSV Options for userId value: \(call.getString("userId"))")
+                        ssvOptions.userIdentifier = call.getString("userId")
+                    }
+                    
+                    if (call.getString("customData") != "") {
+                        NSLog("Enabling SSV Options for customData value: \(call.getString("customData"))")
+                        ssvOptions.customRewardString = call.getString("customData")
+                    }
+                    
+                    self.rewardedAd?.serverSideVerificationOptions = ssvOptions
+                }
+                
                 self.rewardedAd?.fullScreenContentDelegate = self
                 self.plugin?.notifyListeners(RewardAdPluginEvents.Loaded.rawValue, data: [
                     "adUnitId": adUnitID

--- a/ios/Plugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Plugin/Rewarded/AdRewardExecutor.swift
@@ -23,7 +23,7 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
 
                 self.rewardedAd = ad
                 
-                if (call.getString("userId") != "" || call.getString("customData") !== "") {
+                if (call.getString("userId") != "" || call.getString("customData") != "") {
                     let ssvOptions = GADServerSideVerificationOptions()
                     
                     if (call.getString("userId") != "") {

--- a/src/shared/ad-options.interface.ts
+++ b/src/shared/ad-options.interface.ts
@@ -35,4 +35,19 @@ export interface AdOptions {
    * @since 1.2.0
    */
   npa?: boolean;
+
+  /**
+   * For rewarded Ads SSV only.
+   * Set this value to send a user identifier to your rewarded Ads SSV call.
+   * 
+   * @default undefined
+   * @since 3.0.1
+   */
+  userId?: string;
+
+  /**
+   * For rewarded ads SSV only.
+   * Set this value to send custom data to your rewarded ads SSV call.
+   */
+  customData?: string;
 }

--- a/src/shared/ad-options.interface.ts
+++ b/src/shared/ad-options.interface.ts
@@ -48,6 +48,9 @@ export interface AdOptions {
   /**
    * For rewarded ads SSV only.
    * Set this value to send custom data to your rewarded ads SSV call.
+   * 
+   * @default undefined
+   * @since 3.0.1
    */
   customData?: string;
 }


### PR DESCRIPTION
As mentioned in #107, this allows AdMob SSV callbacks to be executed to prevent fradulent access to content that should be locked behind an advert completing. I unfortunately cannot test the code due to having no production app with AdMob enabled yet, and AdMob doesn't send the callbacks to test ads. If anyone could test this code it would be highly appriciated.

Please note this is for Capacitor V3 and not V2, the Capacitor V2 code is here: https://github.com/mattmilan-dev/admob/tree/v1.3.5 But unfortunately i don't know how to open a PR for code that wants to go for version 1.3.5 rather than 3.X.

The app i am running the code with is also a Capacitor V2 app and therefore the above link is code that has been checked as working with the AdMob plugin in a Ionic+Capacitor app with no problems. I don't know if the code submitted for Capacitor V3 also has no problems when paired with a functional app.