### PR TITLE
Feature: Support SSV on Rewarded Ads - Implements SSV Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ export async function interstitial(): Promise<void> {
 ### Show RewardVideo
 
 ```ts
-import { AdMob, AdOptions, AdLoadInfo, RewardAdPluginEvents, AdMobRewardItem } from '@capacitor-community/admob';
+import { AdMob, RewardAdOptions, AdLoadInfo, RewardAdPluginEvents, AdMobRewardItem } from '@capacitor-community/admob';
 
 export async function rewardVideo(): Promise<void> {
   AdMob.addListener(RewardAdPluginEvents.Loaded, (info: AdLoadInfo) => {
@@ -181,10 +181,14 @@ export async function rewardVideo(): Promise<void> {
     console.log(rewardItem);
   });
 
-  const options: AdOptions = {
+  const options: RewardAdOptions = {
     adId: 'YOUR ADID',
     // isTesting: true
     // npa: true
+    // ssv: {
+    //   userId: "A user ID to send to your SSV"
+    //   customData: JSON.stringify({ ...MyCustomData })
+    //}
   };
   await AdMob.prepareRewardVideoAd(options);
   const rewardItem = await AdMob.showRewardVideoAd();
@@ -194,35 +198,68 @@ export async function rewardVideo(): Promise<void> {
 ## Index
 <docgen-index>
 
-* [`initialize(...)`](#initialize)
-* [`trackingAuthorizationStatus()`](#trackingauthorizationstatus)
-* [`showBanner(...)`](#showbanner)
-* [`hideBanner()`](#hidebanner)
-* [`resumeBanner()`](#resumebanner)
-* [`removeBanner()`](#removebanner)
-* [`addListener(BannerAdPluginEvents.SizeChanged, ...)`](#addlistenerbanneradplugineventssizechanged-)
-* [`addListener(BannerAdPluginEvents.Loaded, ...)`](#addlistenerbanneradplugineventsloaded-)
-* [`addListener(BannerAdPluginEvents.FailedToLoad, ...)`](#addlistenerbanneradplugineventsfailedtoload-)
-* [`addListener(BannerAdPluginEvents.Opened, ...)`](#addlistenerbanneradplugineventsopened-)
-* [`addListener(BannerAdPluginEvents.Closed, ...)`](#addlistenerbanneradplugineventsclosed-)
-* [`addListener(BannerAdPluginEvents.AdImpression, ...)`](#addlistenerbanneradplugineventsadimpression-)
-* [`prepareInterstitial(...)`](#prepareinterstitial)
-* [`showInterstitial()`](#showinterstitial)
-* [`addListener(InterstitialAdPluginEvents.FailedToLoad, ...)`](#addlistenerinterstitialadplugineventsfailedtoload-)
-* [`addListener(InterstitialAdPluginEvents.Loaded, ...)`](#addlistenerinterstitialadplugineventsloaded-)
-* [`addListener(InterstitialAdPluginEvents.Dismissed, ...)`](#addlistenerinterstitialadplugineventsdismissed-)
-* [`addListener(InterstitialAdPluginEvents.FailedToShow, ...)`](#addlistenerinterstitialadplugineventsfailedtoshow-)
-* [`addListener(InterstitialAdPluginEvents.Showed, ...)`](#addlistenerinterstitialadplugineventsshowed-)
-* [`prepareRewardVideoAd(...)`](#preparerewardvideoad)
-* [`showRewardVideoAd()`](#showrewardvideoad)
-* [`addListener(RewardAdPluginEvents.FailedToLoad, ...)`](#addlistenerrewardadplugineventsfailedtoload-)
-* [`addListener(RewardAdPluginEvents.Loaded, ...)`](#addlistenerrewardadplugineventsloaded-)
-* [`addListener(RewardAdPluginEvents.Rewarded, ...)`](#addlistenerrewardadplugineventsrewarded-)
-* [`addListener(RewardAdPluginEvents.Dismissed, ...)`](#addlistenerrewardadplugineventsdismissed-)
-* [`addListener(RewardAdPluginEvents.FailedToShow, ...)`](#addlistenerrewardadplugineventsfailedtoshow-)
-* [`addListener(RewardAdPluginEvents.Showed, ...)`](#addlistenerrewardadplugineventsshowed-)
-* [Interfaces](#interfaces)
-* [Enums](#enums)
+- [Maintainers](#maintainers)
+- [Demo](#demo)
+  - [Screenshots](#screenshots)
+- [Installation](#installation)
+  - [Android configuration](#android-configuration)
+  - [iOS configuration](#ios-configuration)
+- [Example](#example)
+  - [Initialize AdMob](#initialize-admob)
+  - [Show Banner](#show-banner)
+  - [Show Interstitial](#show-interstitial)
+  - [Show RewardVideo](#show-rewardvideo)
+- [Index](#index)
+- [API](#api)
+  - [initialize(...)](#initialize)
+  - [trackingAuthorizationStatus()](#trackingauthorizationstatus)
+  - [showBanner(...)](#showbanner)
+  - [hideBanner()](#hidebanner)
+  - [resumeBanner()](#resumebanner)
+  - [removeBanner()](#removebanner)
+  - [addListener(BannerAdPluginEvents.SizeChanged, ...)](#addlistenerbanneradplugineventssizechanged-)
+  - [addListener(BannerAdPluginEvents.Loaded, ...)](#addlistenerbanneradplugineventsloaded-)
+  - [addListener(BannerAdPluginEvents.FailedToLoad, ...)](#addlistenerbanneradplugineventsfailedtoload-)
+  - [addListener(BannerAdPluginEvents.Opened, ...)](#addlistenerbanneradplugineventsopened-)
+  - [addListener(BannerAdPluginEvents.Closed, ...)](#addlistenerbanneradplugineventsclosed-)
+  - [addListener(BannerAdPluginEvents.AdImpression, ...)](#addlistenerbanneradplugineventsadimpression-)
+  - [prepareInterstitial(...)](#prepareinterstitial)
+  - [showInterstitial()](#showinterstitial)
+  - [addListener(InterstitialAdPluginEvents.FailedToLoad, ...)](#addlistenerinterstitialadplugineventsfailedtoload-)
+  - [addListener(InterstitialAdPluginEvents.Loaded, ...)](#addlistenerinterstitialadplugineventsloaded-)
+  - [addListener(InterstitialAdPluginEvents.Dismissed, ...)](#addlistenerinterstitialadplugineventsdismissed-)
+  - [addListener(InterstitialAdPluginEvents.FailedToShow, ...)](#addlistenerinterstitialadplugineventsfailedtoshow-)
+  - [addListener(InterstitialAdPluginEvents.Showed, ...)](#addlistenerinterstitialadplugineventsshowed-)
+  - [prepareRewardVideoAd(...)](#preparerewardvideoad)
+  - [showRewardVideoAd()](#showrewardvideoad)
+  - [addListener(RewardAdPluginEvents.FailedToLoad, ...)](#addlistenerrewardadplugineventsfailedtoload-)
+  - [addListener(RewardAdPluginEvents.Loaded, ...)](#addlistenerrewardadplugineventsloaded-)
+  - [addListener(RewardAdPluginEvents.Rewarded, ...)](#addlistenerrewardadplugineventsrewarded-)
+  - [addListener(RewardAdPluginEvents.Dismissed, ...)](#addlistenerrewardadplugineventsdismissed-)
+  - [addListener(RewardAdPluginEvents.FailedToShow, ...)](#addlistenerrewardadplugineventsfailedtoshow-)
+  - [addListener(RewardAdPluginEvents.Showed, ...)](#addlistenerrewardadplugineventsshowed-)
+  - [Interfaces](#interfaces)
+    - [AdMobInitializationOptions](#admobinitializationoptions)
+    - [TrackingAuthorizationStatusInterface](#trackingauthorizationstatusinterface)
+    - [BannerAdOptions](#banneradoptions)
+    - [PluginListenerHandle](#pluginlistenerhandle)
+    - [AdMobBannerSize](#admobbannersize)
+    - [AdMobError](#admoberror)
+    - [AdLoadInfo](#adloadinfo)
+    - [AdOptions](#adoptions)
+    - [RewardAdOptions](#rewardadoptions)
+    - [AdMobRewardItem](#admobrewarditem)
+  - [Enums](#enums)
+    - [MaxAdContentRating](#maxadcontentrating)
+    - [BannerAdSize](#banneradsize)
+    - [BannerAdPosition](#banneradposition)
+    - [BannerAdPluginEvents](#banneradpluginevents)
+    - [InterstitialAdPluginEvents](#interstitialadpluginevents)
+    - [RewardAdPluginEvents](#rewardadpluginevents)
+- [TROUBLE SHOOTING](#trouble-shooting)
+  - [If you have error:](#if-you-have-error)
+- [License](#license)
+- [Contributors ✨](#contributors-)
 
 </docgen-index>
 
@@ -523,14 +560,14 @@ addListener(eventName: InterstitialAdPluginEvents.Showed, listenerFunc: () => vo
 ### prepareRewardVideoAd(...)
 
 ```typescript
-prepareRewardVideoAd(options: AdOptions) => Promise<AdLoadInfo>
+prepareRewardVideoAd(options: RewardAdOptions) => Promise<AdLoadInfo>
 ```
 
 Prepare a reward video ad
 
 | Param         | Type                                            | Description                        |
 | ------------- | ----------------------------------------------- | ---------------------------------- |
-| **`options`** | <code><a href="#adoptions">AdOptions</a></code> | <a href="#adoptions">AdOptions</a> |
+| **`options`** | <code><a href="#rewardadoptions">RewardAdOptions</a></code> | <a href="#rewardadoptions">RewardAdOptions</a> |
 
 **Returns:** <code>Promise&lt;<a href="#adloadinfo">AdLoadInfo</a>&gt;</code>
 
@@ -722,7 +759,15 @@ https://developers.google.com/android/reference/com/google/android/gms/ads/AdErr
 | **`margin`**    | <code>number</code>  | Margin Banner. Default is 0px; If position is BOTTOM_CENTER, margin is be margin-bottom. If position is TOP_CENTER, margin is be margin-top. |
 | **`npa`**       | <code>boolean</code> | The default behavior of the Google Mobile Ads SDK is to serve personalized ads. Set this to true to request Non-Personalized Ads             |
 
+#### RewardAdOptions
 
+| Prop            | Type                 | Description                                                                                                                                  |
+| --------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`adId`**      | <code>string</code>  | The ad unit ID that you want to request                                                                                                      |
+| **`isTesting`** | <code>boolean</code> | You can use test mode of ad.                                                                                                                 |
+| **`margin`**    | <code>number</code>  | Margin Banner. Default is 0px; If position is BOTTOM_CENTER, margin is be margin-bottom. If position is TOP_CENTER, margin is be margin-top. |
+| **`npa`**       | <code>boolean</code> | The default behavior of the Google Mobile Ads SDK is to serve personalized ads. Set this to true to request Non-Personalized Ads             |
+| **`ssv`**       | <code>{userId: string customData: string}</code>           | If you have enabled SSV in Admob for your rewarded Ads, this allows you to pass a userId and/or customData to your SSV Callback Function.
 #### AdMobRewardItem
 
 For more information

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ export async function rewardVideo(): Promise<void> {
 ```
 
 ## Server-side Verification Notice
-SSV's are only processed on Production Adverts, therefore test Ads will not fire off your SSV callback.
+SSV callbacks are only fired on Production Adverts, therefore test Ads will not fire off your SSV callback.
 
 For E2E tests or just for validating the data in your `RewardAdOptions` work as expected, you can add a custom GET
 request to your mock endpoint after the `RewardAdPluginEvents.Rewarded` similar to this:

--- a/README.md
+++ b/README.md
@@ -195,6 +195,38 @@ export async function rewardVideo(): Promise<void> {
 }
 ```
 
+## Server-side Verification Notice
+SSV's are only processed on Production Adverts, therefore test Ads will not fire off your SSV callback.
+
+For E2E tests or just for validating the data in your `RewardAdOptions` work as expected, you can add a custom GET
+request to your mock endpoint after the `RewardAdPluginEvents.Rewarded` similar to this:
+```ts
+AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
+  // ...
+  if (ENVIRONMENT_IS_DEVELOPMENT) {
+    try {
+      const url = `https://your-staging-ssv-endpoint` + new URLSearchParams({
+        'ad_network': 'TEST',
+        'ad_unit': 'TEST',
+        'custom_data': customData, // <-- passed CustomData
+        'reward_amount': 'TEST',
+        'reward_item': 'TEST',
+        'timestamp': 'TEST',
+        'transaction_id': 'TEST',
+        'user_id': userId, // <-- Passed UserID
+        'signature': 'TEST',
+        'key_id': 'TEST'
+      });
+      await fetch(url);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  // ...
+});
+```
+
+
 ## Index
 <docgen-index>
 
@@ -209,6 +241,7 @@ export async function rewardVideo(): Promise<void> {
   - [Show Banner](#show-banner)
   - [Show Interstitial](#show-interstitial)
   - [Show RewardVideo](#show-rewardvideo)
+- [Server-side Verification Notice](#server-side-verification-notice)
 - [Index](#index)
 - [API](#api)
   - [initialize(...)](#initialize)

--- a/android/src/main/java/com/getcapacitor/community/admob/models/AdOptions.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/models/AdOptions.java
@@ -3,6 +3,7 @@ package com.getcapacitor.community.admob.models;
 import androidx.annotation.VisibleForTesting;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.community.admob.banner.BannerAdSizeEnum;
+import com.getcapacitor.community.admob.rewarded.models.SsvInfo;
 
 /**
  * Holds the options for an Ad Request
@@ -59,6 +60,11 @@ public abstract class AdOptions {
      */
     public final boolean npa;
 
+    /**
+     * Used for Server side verification of Reward Ads
+     */
+    public final SsvInfo ssvInfo;
+
     private AdOptions(PluginCall call) {
         /*
          * TODO: Since the Id in the Typescript AdOptions interface is not optional
@@ -72,18 +78,20 @@ public abstract class AdOptions {
         this.position = call.getString("position", "BOTTOM_CENTER");
         this.margin = call.getInt("margin", 0);
         this.npa = call.getBoolean("npa", false);
+        this.ssvInfo = new SsvInfo(call);
 
         String sizeString = call.getString("adSize", BannerAdSizeEnum.ADAPTIVE_BANNER.name());
         this.adSize = AdOptions.adSizeStringToAdSizeEnum(sizeString);
     }
 
-    private AdOptions(String id, boolean isTesting, String position, int margin, boolean npa, BannerAdSizeEnum adSize) {
+    private AdOptions(String id, boolean isTesting, String position, int margin, boolean npa, BannerAdSizeEnum adSize, SsvInfo ssvInfo) {
         this.adId = id;
         this.isTesting = isTesting;
         this.position = position;
         this.margin = margin;
         this.npa = npa;
         this.adSize = adSize;
+        this.ssvInfo = ssvInfo;
     }
 
     /**
@@ -163,7 +171,12 @@ public abstract class AdOptions {
         private int margin = 1;
         private boolean npa = false;
         private BannerAdSizeEnum adSize = BannerAdSizeEnum.ADAPTIVE_BANNER;
+        private  SsvInfo ssvInfo = new SsvInfo();
 
+        public TesterAdOptionsBuilder setSsvInfo(SsvInfo info) {
+            ssvInfo = info;
+            return this;
+        }
         public TesterAdOptionsBuilder setIsTesting(boolean value) {
             isTesting = value;
             return this;
@@ -200,7 +213,7 @@ public abstract class AdOptions {
         }
 
         public AdOptions build() {
-            return new AdOptions(id, isTesting, position, margin, npa, adSize) {
+            return new AdOptions(id, isTesting, position, margin, npa, adSize, ssvInfo) {
                 @Override
                 public String getTestingId() {
                     return testingID;

--- a/android/src/main/java/com/getcapacitor/community/admob/models/AdOptions.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/models/AdOptions.java
@@ -171,12 +171,13 @@ public abstract class AdOptions {
         private int margin = 1;
         private boolean npa = false;
         private BannerAdSizeEnum adSize = BannerAdSizeEnum.ADAPTIVE_BANNER;
-        private  SsvInfo ssvInfo = new SsvInfo();
+        private SsvInfo ssvInfo = new SsvInfo();
 
         public TesterAdOptionsBuilder setSsvInfo(SsvInfo info) {
             ssvInfo = info;
             return this;
         }
+
         public TesterAdOptionsBuilder setIsTesting(boolean value) {
             isTesting = value;
             return this;

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -13,6 +13,7 @@ import com.getcapacitor.community.admob.models.AdOptions;
 import com.getcapacitor.community.admob.models.Executor;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.rewarded.RewardedAd;
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import com.google.android.gms.common.util.BiConsumer;
 
 public class AdRewardExecutor extends Executor {

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -62,6 +62,25 @@ public class AdRewardExecutor extends Executor {
             return;
         }
 
+        JSObject providedOptions = call.getObject("ssv");
+        if (providedOptions.length() != 0) {
+            ServerSideVerificationOptions.Builder ssvOptions = new ServerSideVerificationOptions.Builder();
+
+            if (providedOptions.has("customData")) {
+                String customData = providedOptions.getString("customData");
+                assert customData != null;
+                ssvOptions.setCustomData(customData);
+            }
+
+            if (providedOptions.has("userId")) {
+                String userId = providedOptions.getString("userId");
+                assert userId != null;
+                ssvOptions.setUserId(userId);
+            }
+
+            mRewardedAd.setServerSideVerificationOptions(ssvOptions.build());
+        }
+
         try {
             activitySupplier
                 .get()

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -2,9 +2,7 @@ package com.getcapacitor.community.admob.rewarded;
 
 import android.app.Activity;
 import android.content.Context;
-
 import androidx.core.util.Supplier;
-
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -22,10 +20,10 @@ public class AdRewardExecutor extends Executor {
     public static RewardedAd mRewardedAd;
 
     public AdRewardExecutor(
-            Supplier<Context> contextSupplier,
-            Supplier<Activity> activitySupplier,
-            BiConsumer<String, JSObject> notifyListenersFunction,
-            String pluginLogTag
+        Supplier<Context> contextSupplier,
+        Supplier<Activity> activitySupplier,
+        BiConsumer<String, JSObject> notifyListenersFunction,
+        String pluginLogTag
     ) {
         super(contextSupplier, activitySupplier, notifyListenersFunction, pluginLogTag, "AdRewardExecutor");
     }
@@ -35,23 +33,23 @@ public class AdRewardExecutor extends Executor {
         final AdOptions adOptions = AdOptions.getFactory().createRewardVideoOptions(call);
 
         activitySupplier
-                .get()
-                .runOnUiThread(
-                        () -> {
-                            try {
-                                final AdRequest adRequest = RequestHelper.createRequest(adOptions);
-                                final String id = AdViewIdHelper.getFinalAdId(adOptions, adRequest, logTag, contextSupplier.get());
-                                RewardedAd.load(
-                                        contextSupplier.get(),
-                                        id,
-                                        adRequest,
-                                        RewardedAdCallbackAndListeners.INSTANCE.getRewardedAdLoadCallback(call, notifyListenersFunction, adOptions)
-                                );
-                            } catch (Exception ex) {
-                                call.reject(ex.getLocalizedMessage(), ex);
-                            }
-                        }
-                );
+            .get()
+            .runOnUiThread(
+                () -> {
+                    try {
+                        final AdRequest adRequest = RequestHelper.createRequest(adOptions);
+                        final String id = AdViewIdHelper.getFinalAdId(adOptions, adRequest, logTag, contextSupplier.get());
+                        RewardedAd.load(
+                            contextSupplier.get(),
+                            id,
+                            adRequest,
+                            RewardedAdCallbackAndListeners.INSTANCE.getRewardedAdLoadCallback(call, notifyListenersFunction, adOptions)
+                        );
+                    } catch (Exception ex) {
+                        call.reject(ex.getLocalizedMessage(), ex);
+                    }
+                }
+            );
     }
 
     @PluginMethod
@@ -66,16 +64,16 @@ public class AdRewardExecutor extends Executor {
 
         try {
             activitySupplier
-                    .get()
-                    .runOnUiThread(
-                            () -> {
-                                mRewardedAd.show(
-                                        activitySupplier.get(),
-                                        RewardedAdCallbackAndListeners.INSTANCE.getOnUserEarnedRewardListener(call, notifyListenersFunction)
-                                );
-                                call.resolve();
-                            }
-                    );
+                .get()
+                .runOnUiThread(
+                    () -> {
+                        mRewardedAd.show(
+                            activitySupplier.get(),
+                            RewardedAdCallbackAndListeners.INSTANCE.getOnUserEarnedRewardListener(call, notifyListenersFunction)
+                        );
+                        call.resolve();
+                    }
+                );
         } catch (Exception ex) {
             call.reject(ex.getLocalizedMessage(), ex);
         }

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -2,7 +2,9 @@ package com.getcapacitor.community.admob.rewarded;
 
 import android.app.Activity;
 import android.content.Context;
+
 import androidx.core.util.Supplier;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -13,7 +15,6 @@ import com.getcapacitor.community.admob.models.AdOptions;
 import com.getcapacitor.community.admob.models.Executor;
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.rewarded.RewardedAd;
-import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import com.google.android.gms.common.util.BiConsumer;
 
 public class AdRewardExecutor extends Executor {
@@ -44,7 +45,7 @@ public class AdRewardExecutor extends Executor {
                             contextSupplier.get(),
                             id,
                             adRequest,
-                            RewardedAdCallbackAndListeners.INSTANCE.getRewardedAdLoadCallback(call, notifyListenersFunction)
+                            RewardedAdCallbackAndListeners.INSTANCE.getRewardedAdLoadCallback(call, notifyListenersFunction, adOptions)
                         );
                     } catch (Exception ex) {
                         call.reject(ex.getLocalizedMessage(), ex);
@@ -61,25 +62,6 @@ public class AdRewardExecutor extends Executor {
             AdMobPluginError errorObject = new AdMobPluginError(-1, errorMessage);
             notifyListenersFunction.accept(RewardAdPluginEvents.FailedToLoad, errorObject);
             return;
-        }
-
-        JSObject providedOptions = call.getObject("ssv");
-        if (providedOptions.length() != 0) {
-            ServerSideVerificationOptions.Builder ssvOptions = new ServerSideVerificationOptions.Builder();
-
-            if (providedOptions.has("customData")) {
-                String customData = providedOptions.getString("customData");
-                assert customData != null;
-                ssvOptions.setCustomData(customData);
-            }
-
-            if (providedOptions.has("userId")) {
-                String userId = providedOptions.getString("userId");
-                assert userId != null;
-                ssvOptions.setUserId(userId);
-            }
-
-            mRewardedAd.setServerSideVerificationOptions(ssvOptions.build());
         }
 
         try {

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -22,10 +22,10 @@ public class AdRewardExecutor extends Executor {
     public static RewardedAd mRewardedAd;
 
     public AdRewardExecutor(
-        Supplier<Context> contextSupplier,
-        Supplier<Activity> activitySupplier,
-        BiConsumer<String, JSObject> notifyListenersFunction,
-        String pluginLogTag
+            Supplier<Context> contextSupplier,
+            Supplier<Activity> activitySupplier,
+            BiConsumer<String, JSObject> notifyListenersFunction,
+            String pluginLogTag
     ) {
         super(contextSupplier, activitySupplier, notifyListenersFunction, pluginLogTag, "AdRewardExecutor");
     }
@@ -35,23 +35,23 @@ public class AdRewardExecutor extends Executor {
         final AdOptions adOptions = AdOptions.getFactory().createRewardVideoOptions(call);
 
         activitySupplier
-            .get()
-            .runOnUiThread(
-                () -> {
-                    try {
-                        final AdRequest adRequest = RequestHelper.createRequest(adOptions);
-                        final String id = AdViewIdHelper.getFinalAdId(adOptions, adRequest, logTag, contextSupplier.get());
-                        RewardedAd.load(
-                            contextSupplier.get(),
-                            id,
-                            adRequest,
-                            RewardedAdCallbackAndListeners.INSTANCE.getRewardedAdLoadCallback(call, notifyListenersFunction, adOptions)
-                        );
-                    } catch (Exception ex) {
-                        call.reject(ex.getLocalizedMessage(), ex);
-                    }
-                }
-            );
+                .get()
+                .runOnUiThread(
+                        () -> {
+                            try {
+                                final AdRequest adRequest = RequestHelper.createRequest(adOptions);
+                                final String id = AdViewIdHelper.getFinalAdId(adOptions, adRequest, logTag, contextSupplier.get());
+                                RewardedAd.load(
+                                        contextSupplier.get(),
+                                        id,
+                                        adRequest,
+                                        RewardedAdCallbackAndListeners.INSTANCE.getRewardedAdLoadCallback(call, notifyListenersFunction, adOptions)
+                                );
+                            } catch (Exception ex) {
+                                call.reject(ex.getLocalizedMessage(), ex);
+                            }
+                        }
+                );
     }
 
     @PluginMethod
@@ -66,16 +66,16 @@ public class AdRewardExecutor extends Executor {
 
         try {
             activitySupplier
-                .get()
-                .runOnUiThread(
-                    () -> {
-                        mRewardedAd.show(
-                            activitySupplier.get(),
-                            RewardedAdCallbackAndListeners.INSTANCE.getOnUserEarnedRewardListener(call, notifyListenersFunction)
-                        );
-                        call.resolve();
-                    }
-                );
+                    .get()
+                    .runOnUiThread(
+                            () -> {
+                                mRewardedAd.show(
+                                        activitySupplier.get(),
+                                        RewardedAdCallbackAndListeners.INSTANCE.getOnUserEarnedRewardListener(call, notifyListenersFunction)
+                                );
+                                call.resolve();
+                            }
+                    );
         } catch (Exception ex) {
             call.reject(ex.getLocalizedMessage(), ex);
         }

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/RewardedAdCallbackAndListeners.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/RewardedAdCallbackAndListeners.kt
@@ -4,11 +4,13 @@ import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.admob.helpers.FullscreenPluginCallback
 import com.getcapacitor.community.admob.models.AdMobPluginError
+import com.getcapacitor.community.admob.models.AdOptions
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.OnUserEarnedRewardListener
 import com.google.android.gms.ads.rewarded.RewardItem
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
 import com.google.android.gms.common.util.BiConsumer
 
 object RewardedAdCallbackAndListeners {
@@ -23,13 +25,24 @@ object RewardedAdCallbackAndListeners {
         }
     }
 
-    fun getRewardedAdLoadCallback(call: PluginCall, notifyListenersFunction: BiConsumer<String, JSObject>): RewardedAdLoadCallback {
+    fun getRewardedAdLoadCallback(call: PluginCall, notifyListenersFunction: BiConsumer<String, JSObject>, adOptions: AdOptions): RewardedAdLoadCallback {
         return object : RewardedAdLoadCallback() {
             override fun onAdLoaded(ad: RewardedAd) {
                 AdRewardExecutor.mRewardedAd = ad
                 AdRewardExecutor.mRewardedAd.fullScreenContentCallback = FullscreenPluginCallback(
                         RewardAdPluginEvents, notifyListenersFunction)
 
+                if(adOptions.ssvInfo.hasInfo){
+                    val ssvOptions = ServerSideVerificationOptions.Builder()
+                    adOptions.ssvInfo.customData?.let {
+                        ssvOptions.setCustomData(it)
+                    }
+
+                    adOptions.ssvInfo.userId?.let {
+                        ssvOptions.setUserId(it)
+                    }
+                    AdRewardExecutor.mRewardedAd.setServerSideVerificationOptions(ssvOptions.build())
+                }
 
                 val adInfo = JSObject()
                 adInfo.put("adUnitId", ad.adUnitId)

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/models/SsvInfo.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/models/SsvInfo.kt
@@ -2,17 +2,20 @@ package com.getcapacitor.community.admob.rewarded.models
 
 import com.getcapacitor.PluginCall
 
-class SsvInfo(val customData: String? = null,
-              val userId: String? = null) {
+class SsvInfo(
+    val customData: String? = null,
+    val userId: String? = null
+) {
 
-    constructor(pluginCall: PluginCall): this(
+    constructor(pluginCall: PluginCall) : this(
         pluginCall.getObject("ssv").getString("customData"),
         pluginCall.getObject("userId").getString("userId")
     )
-    constructor(): this(null, null)
 
-   val hasInfo
-   get(): Boolean {
-       return customData != null || userId != null
-    }
+    constructor() : this(null, null)
+
+    val hasInfo
+        get(): Boolean {
+            return customData != null || userId != null
+        }
 }

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/models/SsvInfo.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/models/SsvInfo.kt
@@ -4,12 +4,11 @@ import com.getcapacitor.PluginCall
 
 class SsvInfo(
     val customData: String? = null,
-    val userId: String? = null
-) {
+    val userId: String? = null) {
 
-    constructor(pluginCall: PluginCall) : this(
-        pluginCall.getObject("ssv").getString("customData"),
-        pluginCall.getObject("userId").getString("userId")
+    constructor(pluginCall: PluginCall?) : this(
+        pluginCall?.getObject("ssv")?.getString("customData"),
+        pluginCall?.getObject("ssv")?.getString("userId")
     )
 
     constructor() : this(null, null)

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/models/SsvInfo.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/models/SsvInfo.kt
@@ -1,0 +1,18 @@
+package com.getcapacitor.community.admob.rewarded.models
+
+import com.getcapacitor.PluginCall
+
+class SsvInfo(val customData: String? = null,
+              val userId: String? = null) {
+
+    constructor(pluginCall: PluginCall): this(
+        pluginCall.getObject("ssv").getString("customData"),
+        pluginCall.getObject("userId").getString("userId")
+    )
+    constructor(): this(null, null)
+
+   val hasInfo
+   get(): Boolean {
+       return customData != null || userId != null
+    }
+}

--- a/android/src/test/java/com/getcapacitor/community/admob/models/AdOptionsTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/models/AdOptionsTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -13,7 +14,6 @@ import static org.mockito.Mockito.when;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.community.admob.rewarded.models.SsvInfo;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -114,7 +114,7 @@ public class AdOptionsTest {
 
             final AdOptions adOptions = AdOptions.getFactory().createGenericOptions(pluginCallMock, "");
 
-            verify(pluginCallMock).getObject(wantedProperty);
+            verify(pluginCallMock, atLeastOnce()).getObject(wantedProperty);
             assertEquals(userId, adOptions.ssvInfo.getUserId());
             assertEquals(customData, adOptions.ssvInfo.getCustomData());
         }

--- a/android/src/test/java/com/getcapacitor/community/admob/models/AdOptionsTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/models/AdOptionsTest.java
@@ -10,7 +10,10 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
+import com.getcapacitor.community.admob.rewarded.models.SsvInfo;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -98,24 +101,22 @@ public class AdOptionsTest {
             verify(pluginCallMock).getBoolean(wantedProperty, defaultValue);
             assertEquals(expected, adOptions.npa);
         }
-        //    @Test
-        //    public void testingDevices() {
-        //      final String wantedProperty = "testingDevices";
-        //      final JSArray expected = new JSArray();
-        //      expected.put("one").put("two");
-        //      when(
-        //          pluginCallMock.getArray(
-        //            eq(wantedProperty),
-        //            Mockito.any(JSArray.class)
-        //          )
-        //        )
-        //        .thenReturn(expected);
-        //
-        //      final AdOptions adOptions = AdOptions.getFactory().createGenericOptions(pluginCallMock, "");
-        //
-        //      verify(pluginCallMock)
-        //        .getArray(wantedProperty, AdOptions.getFactory().EMPTY_TESTING_DEVICES);
-        //      assertEquals(expected, adOptions.testingDevices);
-        //    }
+
+        @Test
+        public void ssv() {
+            final String customData = "customData";
+            final String userId = "userId";
+            final String wantedProperty = "ssv";
+            final JSObject expected = new JSObject();
+            expected.put(customData, customData);
+            expected.put(userId, userId);
+            lenient().when(pluginCallMock.getObject(eq(wantedProperty))).thenReturn(expected);
+
+            final AdOptions adOptions = AdOptions.getFactory().createGenericOptions(pluginCallMock, "");
+
+            verify(pluginCallMock).getObject(wantedProperty);
+            assertEquals(userId, adOptions.ssvInfo.getUserId());
+            assertEquals(customData, adOptions.ssvInfo.getCustomData());
+        }
     }
 }

--- a/android/src/test/java/com/getcapacitor/community/admob/rewarded/RewardedAdCallbackAndListenersTest.kt
+++ b/android/src/test/java/com/getcapacitor/community/admob/rewarded/RewardedAdCallbackAndListenersTest.kt
@@ -35,10 +35,10 @@ internal class RewardedAdCallbackAndListenersTest {
     lateinit var context: Context
 
     @Mock
-    lateinit var  activity: Activity
+    lateinit var activity: Activity
 
     @Mock
-    lateinit var  notifierMock: BiConsumer<String, JSObject>
+    lateinit var notifierMock: BiConsumer<String, JSObject>
 
     @Mock
     lateinit var pluginCall: PluginCall
@@ -49,8 +49,10 @@ internal class RewardedAdCallbackAndListenersTest {
     fun beforeEach() {
         Mockito.reset(context, activity, notifierMock)
         Mockito.verify(pluginCall, never()).resolve(any()) // Always a clean call
-        listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(pluginCall,
-            notifierMock, AdOptions.TesterAdOptionsBuilder().build())
+        listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(
+            pluginCall,
+            notifierMock, AdOptions.TesterAdOptionsBuilder().build()
+        )
     }
 
     @Nested
@@ -70,12 +72,18 @@ internal class RewardedAdCallbackAndListenersTest {
         @Test
         fun `onRewarded should emit the Reward Item info`() {
             val argumentCaptor = ArgumentCaptor.forClass(JSObject::class.java)
-            val listener = RewardedAdCallbackAndListeners.getOnUserEarnedRewardListener(pluginCall, notifierMock)
+            val listener = RewardedAdCallbackAndListeners.getOnUserEarnedRewardListener(
+                pluginCall,
+                notifierMock
+            )
 
             // ACt
             listener.onUserEarnedReward(rewardItem)
 
-            Mockito.verify(notifierMock).accept(ArgumentMatchers.eq(RewardAdPluginEvents.Rewarded), argumentCaptor.capture())
+            Mockito.verify(notifierMock).accept(
+                ArgumentMatchers.eq(RewardAdPluginEvents.Rewarded),
+                argumentCaptor.capture()
+            )
             val emittedItem = argumentCaptor.value
             assertEquals(emittedItem.getString("type"), wantedType)
             assertEquals(emittedItem.getInt("amount"), wantedAmount)
@@ -84,7 +92,10 @@ internal class RewardedAdCallbackAndListenersTest {
         @Test
         fun `onRewarded should resolve the Reward Item info`() {
             val argumentCaptor = ArgumentCaptor.forClass(JSObject::class.java)
-            val listener = RewardedAdCallbackAndListeners.getOnUserEarnedRewardListener(pluginCall, notifierMock)
+            val listener = RewardedAdCallbackAndListeners.getOnUserEarnedRewardListener(
+                pluginCall,
+                notifierMock
+            )
 
             // ACt
             listener.onUserEarnedReward(rewardItem)
@@ -108,7 +119,6 @@ internal class RewardedAdCallbackAndListenersTest {
             lateinit var loadAdErrorMock: LoadAdError
 
 
-
             @BeforeEach
             fun beforeEach() {
                 Mockito.`when`(loadAdErrorMock.code).thenReturn(wantedErrorCode)
@@ -118,13 +128,18 @@ internal class RewardedAdCallbackAndListenersTest {
             @Test
             fun `onAdFailedToLoad should emit the the error code and reason in a FailedToLoad event`() {
                 val argumentCaptor = ArgumentCaptor.forClass(JSObject::class.java)
-                val listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(pluginCall,
-                    notifierMock, AdOptions.TesterAdOptionsBuilder().build())
+                val listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(
+                    pluginCall,
+                    notifierMock, AdOptions.TesterAdOptionsBuilder().build()
+                )
 
                 // ACt
                 listener.onAdFailedToLoad(loadAdErrorMock)
 
-                Mockito.verify(notifierMock).accept(ArgumentMatchers.eq(RewardAdPluginEvents.FailedToLoad), argumentCaptor.capture())
+                Mockito.verify(notifierMock).accept(
+                    ArgumentMatchers.eq(RewardAdPluginEvents.FailedToLoad),
+                    argumentCaptor.capture()
+                )
                 val emittedError = argumentCaptor.value
 
                 assertEquals(wantedErrorCode, emittedError.getInt("code"))
@@ -164,7 +179,10 @@ internal class RewardedAdCallbackAndListenersTest {
                 // ACt
                 listener.onAdLoaded(rewardedAdMock)
 
-                Mockito.verify(notifierMock).accept(ArgumentMatchers.eq(RewardAdPluginEvents.Loaded), argumentCaptor.capture())
+                Mockito.verify(notifierMock).accept(
+                    ArgumentMatchers.eq(RewardAdPluginEvents.Loaded),
+                    argumentCaptor.capture()
+                )
                 val emittedAdInfo = argumentCaptor.value
 
                 assertEquals(wantedAdUnitId, emittedAdInfo.getString("adUnitId"))
@@ -175,17 +193,21 @@ internal class RewardedAdCallbackAndListenersTest {
 
                 mockConstruction(ServerSideVerificationOptions.Builder::class.java).use { ssvOptionsMockedConstruction ->
 
-                    val adOptions = AdOptions.TesterAdOptionsBuilder().setSsvInfo(SsvInfo("customData", null)).build()
+                    val adOptions =
+                        AdOptions.TesterAdOptionsBuilder().setSsvInfo(SsvInfo("customData", null))
+                            .build()
 
-                    listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(pluginCall,
-                        notifierMock, adOptions)
+                    listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(
+                        pluginCall,
+                        notifierMock, adOptions
+                    )
 
                     // Act
                     listener.onAdLoaded(rewardedAdMock)
 
                     val ssvOptions = ssvOptionsMockedConstruction.constructed()[0]
-                        verify(ssvOptions).setCustomData(adOptions.ssvInfo.customData!!)
-                        verify(ssvOptions, times(0)).setUserId(any())
+                    verify(ssvOptions).setCustomData(adOptions.ssvInfo.customData!!)
+                    verify(ssvOptions, times(0)).setUserId(any())
 
                 }
             }
@@ -195,10 +217,14 @@ internal class RewardedAdCallbackAndListenersTest {
 
                 mockConstruction(ServerSideVerificationOptions.Builder::class.java).use { ssvOptionsMockedConstruction ->
 
-                    val adOptions = AdOptions.TesterAdOptionsBuilder().setSsvInfo(SsvInfo(null, "userId")).build()
+                    val adOptions =
+                        AdOptions.TesterAdOptionsBuilder().setSsvInfo(SsvInfo(null, "userId"))
+                            .build()
 
-                    listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(pluginCall,
-                        notifierMock, adOptions)
+                    listener = RewardedAdCallbackAndListeners.getRewardedAdLoadCallback(
+                        pluginCall,
+                        notifierMock, adOptions
+                    )
 
                     // Act
                     listener.onAdLoaded(rewardedAdMock)
@@ -219,13 +245,14 @@ internal class RewardedAdCallbackAndListenersTest {
     @Nested
     inner class FullScreenContentCallback {
         private lateinit var argumentCaptor: ArgumentCaptor<JSObject>
-        private lateinit var  listener: com.google.android.gms.ads.FullScreenContentCallback
+        private lateinit var listener: com.google.android.gms.ads.FullScreenContentCallback
 
         @BeforeEach
         fun beforeEach() {
             argumentCaptor = ArgumentCaptor.forClass(JSObject::class.java)
             listener = FullscreenPluginCallback(
-                    RewardAdPluginEvents, notifierMock)
+                RewardAdPluginEvents, notifierMock
+            )
         }
 
         @Nested
@@ -237,13 +264,16 @@ internal class RewardedAdCallbackAndListenersTest {
                 // ACt
                 listener.onAdShowedFullScreenContent()
 
-                Mockito.verify(notifierMock).accept(ArgumentMatchers.eq(RewardAdPluginEvents.Showed), argumentCaptor.capture())
+                Mockito.verify(notifierMock).accept(
+                    ArgumentMatchers.eq(RewardAdPluginEvents.Showed),
+                    argumentCaptor.capture()
+                )
             }
 
             @Test
             fun `onAdFailedToShowFullScreenContent call FailedToShow event listener `() {
-                 var wantedReason = "This is the reason"
-                 var wantedErrorCode = 1
+                var wantedReason = "This is the reason"
+                var wantedErrorCode = 1
                 var adErrorMock = Mockito.mock(AdError::class.java);
                 Mockito.`when`(adErrorMock.code).thenReturn(wantedErrorCode)
                 Mockito.`when`(adErrorMock.message).thenReturn(wantedReason)
@@ -251,7 +281,10 @@ internal class RewardedAdCallbackAndListenersTest {
                 // ACt
                 listener.onAdFailedToShowFullScreenContent(adErrorMock)
 
-                Mockito.verify(notifierMock).accept(ArgumentMatchers.eq(RewardAdPluginEvents.FailedToShow), argumentCaptor.capture())
+                Mockito.verify(notifierMock).accept(
+                    ArgumentMatchers.eq(RewardAdPluginEvents.FailedToShow),
+                    argumentCaptor.capture()
+                )
                 val emittedError = argumentCaptor.value
 
                 assertEquals(wantedErrorCode, emittedError.getInt("code"))
@@ -264,7 +297,10 @@ internal class RewardedAdCallbackAndListenersTest {
                 // ACt
                 listener.onAdDismissedFullScreenContent()
 
-                Mockito.verify(notifierMock).accept(ArgumentMatchers.eq(RewardAdPluginEvents.Dismissed), argumentCaptor.capture())
+                Mockito.verify(notifierMock).accept(
+                    ArgumentMatchers.eq(RewardAdPluginEvents.Dismissed),
+                    argumentCaptor.capture()
+                )
             }
         }
     }

--- a/ios/Plugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Plugin/Rewarded/AdRewardExecutor.swift
@@ -22,6 +22,23 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
                 }
 
                 self.rewardedAd = ad
+
+                if let providedOptions = call.getObject("ssv") {
+                    let ssvOptions = GADServerSideVerificationOptions()
+
+                    if let customData = providedOptions["customData"] as? String {
+                        NSLog("Sending Custom Data: \(customData) to SSV callback");
+                        ssvOptions.customRewardString = customData
+                    }
+
+                    if let userId = providedOptions["userId"] as? String {
+                        NSLog("Sending UserId: \(userId) to SSV callback");
+                        ssvOptions.userIdentifier = userId
+                    }
+
+                    self.rewardedAd?.serverSideVerificationOptions = ssvOptions
+                }
+
                 self.rewardedAd?.fullScreenContentDelegate = self
                 self.plugin?.notifyListeners(RewardAdPluginEvents.Loaded.rawValue, data: [
                     "adUnitId": adUnitID

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
     "eslint": "^7.11.0",
-    "husky": "^4.0.0",
+    "husky": "^4.3.8",
     "lint-staged": "^11.0.0",
     "np": "^7.4.0",
     "pre-commit": "^1.2.2",

--- a/src/reward/index.ts
+++ b/src/reward/index.ts
@@ -1,3 +1,4 @@
 export * from './reward-ad-plugin-events.enum';
 export * from './reward-definitions.interface';
 export * from './reward-item.interface';
+export * from './reward-ad-options.interface';

--- a/src/reward/reward-ad-options.interface.ts
+++ b/src/reward/reward-ad-options.interface.ts
@@ -1,0 +1,24 @@
+import type { AdOptions } from '../shared/ad-options.interface';
+
+// This is a type to ensure that IF ssv is provided, at least one of userId or customData is required.
+type AtLeastOne<T> = {[K in keyof T]: Pick<T, K>}[keyof T];
+
+// Because only RewardedAds use SSV. This interface is only available for RewardedAds
+export interface RewardAdOptions extends AdOptions {
+  /**
+   * If you have enabled SSV in your AdMob Application. You can provide customData or
+   * a userId be passed to your callback to do further processing on.
+   * 
+   * @see https://support.google.com/admob/answer/9603226?hl=en-GB
+   */
+  ssv?: AtLeastOne<{
+    /**
+     * An optional UserId to pass to your SSV callback function.
+     */
+    userId: string;
+    /**
+     * An optional custom set of data to pass to your SSV callback function.
+     */
+    customData: string;
+  }>;
+}

--- a/src/reward/reward-ad-options.interface.ts
+++ b/src/reward/reward-ad-options.interface.ts
@@ -9,6 +9,8 @@ export interface RewardAdOptions extends AdOptions {
    * If you have enabled SSV in your AdMob Application. You can provide customData or
    * a userId be passed to your callback to do further processing on.
    * 
+   * *Important* You *HAVE* to define one of them.
+   * 
    * @see https://support.google.com/admob/answer/9603226?hl=en-GB
    */
   ssv?: AtLeastOne<{

--- a/src/reward/reward-definitions.interface.ts
+++ b/src/reward/reward-definitions.interface.ts
@@ -1,8 +1,9 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented} from '../private/validate-all-events-implemented.type'
-import type { AdLoadInfo, AdMobError, AdOptions } from '../shared';
+import type { AdLoadInfo, AdMobError } from '../shared';
 
+import type { RewardAdOptions } from './reward-ad-options.interface';
 import type { RewardAdPluginEvents } from './reward-ad-plugin-events.enum';
 import type { AdMobRewardItem } from './reward-item.interface';
 
@@ -14,10 +15,10 @@ export interface RewardDefinitions {
    * Prepare a reward video ad
    *
    * @group RewardVideo
-   * @param options AdOptions
+   * @param options RewardAdOptions
    * @since 1.1.2
    */
-     prepareRewardVideoAd(options: AdOptions): Promise<AdLoadInfo>;
+     prepareRewardVideoAd(options: RewardAdOptions): Promise<AdLoadInfo>;
 
      /**
       * Show a reward video ad


### PR DESCRIPTION
Currently still to test with production ads on Android, as my AdMob says there aren't any Ads available at the moment. Once tested i can confirm it is working on both platforms. Android code may require some changes to fall more in line with the current code style. I don't know Swift/Java but have had more success implementing the iOS code over the Java code.

Feedback is welcome 😃 

Closes #107 on merge.