### PR TITLE
docs(README): change registerPlugin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ import android.os.Bundle;
 public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
         registerPlugin(com.getcapacitor.community.admob.AdMob.class);
+        super.onCreate(savedInstanceState);
     }
 }
 ```


### PR DESCRIPTION
With Capacitor 4 the plugins should be registered **before** calling `super.onCreate(savedInstanceState);`.
See: [Updating from Capacitor 3 to Capacitor 4](https://capacitorjs.com/docs/updating/4-0#change-registerplugin-order)