### PR TITLE
docs: Remove registerPlugin step

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,6 @@ capacitor 3:
 
 ### Android configuration
 
-In file `android/app/src/main/java/**/**/MainActivity.java`, add the plugin to the initialization list:
-
-```java
-import android.os.Bundle;
-
-public class MainActivity extends BridgeActivity {
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        registerPlugin(com.getcapacitor.community.admob.AdMob.class);
-        super.onCreate(savedInstanceState);
-    }
-}
-```
-
 In file `android/app/src/main/AndroidManifest.xml`, add the following XML elements under `<manifest><application>` :
 
 ```xml
@@ -820,7 +806,9 @@ https://developers.google.com/admob/android/rewarded-video-adapters?hl=en
 
 From T, pick a set of properties whose keys are in the union K
 
-<code>{ [P in K]: T[P]; }</code>
+<code>{
+ [P in K]: T[P];
+ }</code>
 
 
 ### Enums

--- a/demo/angular/android/app/src/main/java/io/ionic/starter/MainActivity.java
+++ b/demo/angular/android/app/src/main/java/io/ionic/starter/MainActivity.java
@@ -3,11 +3,4 @@ package io.ionic.starter;
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        registerPlugin(com.getcapacitor.community.admob.AdMob.class);
-    }
-}
+public class MainActivity extends BridgeActivity {}


### PR DESCRIPTION
Capacitor 3 introduced the automatic plugin registration, so calling `registerPlugin` is not needed and even discouraged.
`registerPlugin` is only used for local plugins not published on npm.

I've removed the step on the README and also the call on the demo app and the app keeps working as expected.