### PR TITLE
chore(readme): Update install instructions for Capacitor 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Made with [contributors-img](https://contrib.rocks).
 If you use capacitor 4:
 
 ```
-% npm install --save @capacitor-community/admob@next
+% npm install --save @capacitor-community/admob@latest
 % npx cap update
 ```
 
 capacitor 3:
 
 ```
-% npm install --save @capacitor-community/admob
+% npm install --save @capacitor-community/admob@3.3.0
 % npx cap update
 ```
 


### PR DESCRIPTION
Version 4 of the plugin is now published on latest tag, next tag is out of date.

For Capacitor 3 users, they should use version 3 instead of latest