### PR TITLE
feat(android): Add playServicesAdsVersion variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ In file `android/app/src/main/res/values/strings.xml` add the following lines :
 
 Don't forget to replace `[APP_ID]` by your AdMob application Id.
 
+#### Variables
+
+This plugin will use the following project variables (defined in your app's `variables.gradle` file):
+
+- `$playServicesAdsVersion` version of `com.google.android.gms:play-services-ads` (default: `21.1.0`)
+
 ### iOS configuration
 
 Add the following in the `ios/App/App/info.plist` file inside of the outermost `<dict>`:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,8 @@ ext {
     androidxCoordinatorLayoutVersion = project.hasProperty('androidxCoordinatorLayoutVersion') ? rootProject.ext.androidxCoordinatorLayoutVersion : '1.2.0'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.3'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.4.0'
+    playServicesAdsVersion = project.hasProperty('playServicesAdsVersion') ? rootProject.ext.playServicesAdsVersion : '21.1.0'
+
 }
 
 buildscript {
@@ -73,7 +75,7 @@ dependencies {
     //    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 
 	// after 20.5.0, require minCompileSdk (31)
-    implementation 'com.google.android.gms:play-services-ads:21.1.0'
+    implementation "com.google.android.gms:play-services-ads:$playServicesAdsVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-ktx:1.6.0"


### PR DESCRIPTION
To prevent conflicts with other plugins and/or allowing users to use a newer `com.google.android.gms:play-services-ads` version without the need of updating the plugin.