### PR TITLE
Revert "refactor(ios): Use plugin viewController instead of rootViewController"

### DIFF
--- a/ios/Plugin/Banner/BannerExecutor.swift
+++ b/ios/Plugin/Banner/BannerExecutor.swift
@@ -7,7 +7,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
     var bannerView: GADBannerView!
 
     func showBanner(_ call: CAPPluginCall, _ request: GADRequest, _ adUnitID: String) {
-        if let rootViewController = plugin?.bridge?.viewController {
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
 
             let adSize = call.getString("adSize") ?? "ADAPTIVE_BANNER"
             let adPosition = call.getString("position") ?? "BOTTOM_CENTER"
@@ -53,7 +53,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
             self.addBannerViewToView(self.bannerView, adPosition, adMargin)
             self.bannerView.translatesAutoresizingMaskIntoConstraints = false
             self.bannerView.adUnitID = adUnitID
-            self.bannerView.rootViewController = plugin?.bridge?.viewController
+            self.bannerView.rootViewController = UIApplication.shared.keyWindow?.rootViewController
 
             self.bannerView.load(request)
             self.bannerView.delegate = self
@@ -64,7 +64,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
 
     func hideBanner(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
-            if let rootViewController = self.plugin?.bridge?.viewController {
+            if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
                 if let subView = rootViewController.view.viewWithTag(2743243288699) {
                     NSLog("AdMob: find subView for hideBanner")
                     subView.isHidden = true
@@ -83,7 +83,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
     }
 
     func resumeBanner(_ call: CAPPluginCall) {
-        if let rootViewController = plugin?.bridge?.viewController {
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
             if let subView = rootViewController.view.viewWithTag(2743243288699) {
                 NSLog("AdMob: find subView for resumeBanner")
                 subView.isHidden = false
@@ -109,7 +109,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
 
     private func addBannerViewToView(_ bannerView: GADBannerView, _ adPosition: String, _ Margin: Int) {
         removeBannerViewToView()
-        if let rootViewController = plugin?.bridge?.viewController {
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
 
             bannerView.translatesAutoresizingMaskIntoConstraints = false
             bannerView.tag = 2743243288699 // rand
@@ -134,7 +134,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
     }
 
     private func removeBannerViewToView() {
-        if let rootViewController = plugin?.bridge?.viewController {
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
             if let subView = rootViewController.view.viewWithTag(2743243288699) {
                 bannerView.delegate = nil
                 NSLog("AdMob: find subView")

--- a/ios/Plugin/Interstitial/AdInterstitialExecutor.swift
+++ b/ios/Plugin/Interstitial/AdInterstitialExecutor.swift
@@ -32,7 +32,7 @@ class AdInterstitialExecutor: NSObject, GADFullScreenContentDelegate {
     }
 
     func showInterstitial(_ call: CAPPluginCall) {
-        if let rootViewController = plugin?.bridge?.viewController {
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
             if let ad = self.interstitial {
                 ad.present(fromRootViewController: rootViewController)
                 call.resolve([:])
@@ -50,7 +50,7 @@ class AdInterstitialExecutor: NSObject, GADFullScreenContentDelegate {
             "message": error.localizedDescription
         ])
     }
-
+    
     public func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         NSLog("InterstitialFullScreenDelegate Ad did present full screen content.")
         self.plugin?.notifyListeners(InterstitialAdPluginEvents.Showed.rawValue, data: [:])

--- a/ios/Plugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Plugin/Rewarded/AdRewardExecutor.swift
@@ -49,7 +49,7 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
     }
 
     func showRewardVideoAd(_ call: CAPPluginCall) {
-        if let rootViewController = plugin?.bridge?.viewController {
+        if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
             if let ad = self.rewardedAd {
                 ad.present(fromRootViewController: rootViewController,
                            userDidEarnRewardHandler: {
@@ -71,7 +71,7 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
             "message": error.localizedDescription
         ])
     }
-
+    
     public func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         NSLog("RewardFullScreenDelegate Ad did present full screen content.")
         self.plugin?.notifyListeners(RewardAdPluginEvents.Showed.rawValue, data: [:])


### PR DESCRIPTION
Reverts capacitor-community/admob#203

Primary: https://github.com/capacitor-community/admob/pull/204