### PR TITLE
Add setApplicationMuted and setApplicationVolume methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
 
 * [`initialize(...)`](#initialize)
 * [`trackingAuthorizationStatus()`](#trackingauthorizationstatus)
+* [`setApplicationMuted(...)`](#setapplicationmuted)
+* [`setApplicationVolume(...)`](#setapplicationvolume)
 * [`showBanner(...)`](#showbanner)
 * [`hideBanner()`](#hidebanner)
 * [`resumeBanner()`](#resumebanner)
@@ -313,6 +315,36 @@ trackingAuthorizationStatus() => Promise<TrackingAuthorizationStatusInterface>
 Confirm requestTrackingAuthorization status (iOS &gt;14)
 
 **Returns:** <code>Promise&lt;<a href="#trackingauthorizationstatusinterface">TrackingAuthorizationStatusInterface</a>&gt;</code>
+
+--------------------
+
+
+### setApplicationMuted(...)
+
+```typescript
+setApplicationMuted(options: ApplicationMutedOptions) => Promise<void>
+```
+
+Report application mute state to AdMob SDK
+
+| Param         | Type                                                                        |
+| ------------- | --------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#applicationmutedoptions">ApplicationMutedOptions</a></code> |
+
+--------------------
+
+
+### setApplicationVolume(...)
+
+```typescript
+setApplicationVolume(options: ApplicationVolumeOptions) => Promise<void>
+```
+
+Report application volume to AdMob SDK
+
+| Param         | Type                                                                          |
+| ------------- | ----------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#applicationvolumeoptions">ApplicationVolumeOptions</a></code> |
 
 --------------------
 
@@ -727,6 +759,20 @@ addListener(eventName: RewardAdPluginEvents.Showed, listenerFunc: () => void) =>
 | **`status`** | <code>'authorized' \| 'denied' \| 'notDetermined' \| 'restricted'</code> |
 
 
+#### ApplicationMutedOptions
+
+| Prop        | Type                 | Description                                                                                                                                                                                                                                                                                           |
+| ----------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`muted`** | <code>boolean</code> | To inform the SDK that the app volume has been muted. Note: Video ads that are ineligible to be shown with muted audio are not returned for ad requests made, when the app volume is reported as muted or set to a value of 0. This may restrict a subset of the broader video ads pool from serving. |
+
+
+#### ApplicationVolumeOptions
+
+| Prop         | Type                                                                               | Description                                                                                                                                                                                                                          |
+| ------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`volume`** | <code>0 \| 1 \| 0.1 \| 0.2 \| 0.3 \| 0.4 \| 0.5 \| 0.6 \| 0.7 \| 0.8 \| 0.9</code> | If your app has its own volume controls (such as custom music or sound effect volumes), disclosing app volume to the Google Mobile Ads SDK allows video ads to respect app volume settings. enable set 0.0 - 1.0, any float allowed. |
+
+
 #### BannerAdOptions
 
 This interface extends <a href="#adoptions">AdOptions</a>
@@ -812,9 +858,7 @@ https://developers.google.com/admob/android/rewarded-video-adapters?hl=en
 
 From T, pick a set of properties whose keys are in the union K
 
-<code>{
- [P in K]: T[P];
- }</code>
+<code>{ [P in K]: T[P]; }</code>
 
 
 ### Enums

--- a/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
@@ -73,6 +73,20 @@ public class AdMob extends Plugin {
         call.resolve(response);
     }
 
+    @PluginMethod
+    public void setApplicationMuted(final PluginCall call) {
+        boolean muted = call.getBoolean("muted");
+        MobileAds.setAppMuted(muted);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void setApplicationVolume(final PluginCall call) {
+        float volume = call.getFloat("volume");
+        MobileAds.setAppVolume(volume);
+        call.resolve();
+    }
+
     // Show a banner Ad
     @PluginMethod
     public void showBanner(final PluginCall call) {

--- a/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
@@ -75,14 +75,22 @@ public class AdMob extends Plugin {
 
     @PluginMethod
     public void setApplicationMuted(final PluginCall call) {
-        boolean muted = call.getBoolean("muted");
+        Boolean muted = call.getBoolean("muted");
+        if (muted == null) {
+            call.reject("muted property cannot be null");
+            return;
+        }
         MobileAds.setAppMuted(muted);
         call.resolve();
     }
 
     @PluginMethod
     public void setApplicationVolume(final PluginCall call) {
-        float volume = call.getFloat("volume");
+        Float volume = call.getFloat("volume");
+        if (volume == null) {
+            call.reject("volume property cannot be null");
+            return;
+        }
         MobileAds.setAppVolume(volume);
         call.resolve();
     }

--- a/demo/angular/src/app/app.component.ts
+++ b/demo/angular/src/app/app.component.ts
@@ -24,6 +24,14 @@ export class AppComponent {
         testingDevices: ['2077ef9a63d2b398840261c8221a0c9b'],
         initializeForTesting: true,
       });
+
+      AdMob.setApplicationMuted({
+        muted: false,
+      });
+
+      AdMob.setApplicationVolume({
+        volume: 0.5,
+      });
     });
   }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -6,6 +6,8 @@
 CAP_PLUGIN(AdMob, "AdMob",
            CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(trackingAuthorizationStatus, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setApplicationMuted, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setApplicationVolume, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(showBanner, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(resumeBanner, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(hideBanner, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -48,6 +48,25 @@ public class AdMob: CAPPlugin {
             call.resolve([:])
         }
     }
+    
+    @objc func setApplicationMuted(_ call: CAPPluginCall) {
+        var shouldMute = call.getBool("muted") ?? false
+        GADMobileAds.sharedInstance().applicationMuted = shouldMute
+        
+        call.resolve([:])
+    }
+    
+    @objc func setApplicationVolume(_ call: CAPPluginCall) {
+        var volume = call.getFloat("volume") ?? 1
+        
+        //Clamp volumes. 
+        if (volume < 0.0) {volume = 0.0}
+        else if (volume > 1.0) {volume = 1.0}
+        
+        GADMobileAds.sharedInstance().applicationVolume = volume
+
+        call.resolve([:])
+    }
 
     /**
      *  AdMob: Banner

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -50,22 +50,28 @@ public class AdMob: CAPPlugin {
     }
     
     @objc func setApplicationMuted(_ call: CAPPluginCall) {
-        var shouldMute = call.getBool("muted") ?? false
-        GADMobileAds.sharedInstance().applicationMuted = shouldMute
-        
-        call.resolve([:])
+        if let shouldMute = call.getBool("muted") {
+            GADMobileAds.sharedInstance().applicationMuted = shouldMute
+            call.resolve([:])
+        } else {
+            call.reject("muted property cannot be null");
+            return;
+        }
     }
     
     @objc func setApplicationVolume(_ call: CAPPluginCall) {
-        var volume = call.getFloat("volume") ?? 1
-        
-        //Clamp volumes. 
-        if (volume < 0.0) {volume = 0.0}
-        else if (volume > 1.0) {volume = 1.0}
-        
-        GADMobileAds.sharedInstance().applicationVolume = volume
+        if var volume = call.getFloat("volume") {
+            //Clamp volumes. 
+            if (volume < 0.0) {volume = 0.0}
+            else if (volume > 1.0) {volume = 1.0}
+            
+            GADMobileAds.sharedInstance().applicationVolume = volume
 
-        call.resolve([:])
+            call.resolve([:])
+        } else {
+            call.reject("volume property cannot be null");
+            return;
+        }
     }
 
     /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -24,6 +24,22 @@ export interface AdMobPlugin extends AdMobDefinitions {
    * @since 3.1.0
    */
   trackingAuthorizationStatus(): Promise<TrackingAuthorizationStatusInterface>;
+
+  /**
+   * Report application mute state to AdMob SDK
+   *
+   * @see https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547038-trackingauthorizationstatus
+   * @since 4.1.1
+   */
+  setApplicationMuted(options: ApplicationMutedOptions): Promise<void>;
+
+  /**
+   * Report application volume to AdMob SDK
+   *
+   * @see https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547038-trackingauthorizationstatus
+   * @since 4.1.1
+   */
+  setApplicationVolume(options: ApplicationVolumeOptions): Promise<void>;
 }
 
 export interface AdMobInitializationOptions {
@@ -102,4 +118,28 @@ export enum MaxAdContentRating {
    * Content suitable only for mature audiences.
    */
   MatureAudience = 'MatureAudience',
+}
+
+export interface ApplicationMutedOptions {
+  /**
+   * To inform the SDK that the app volume has been muted.
+   * Note: Video ads that are ineligible to be shown with muted audio are not returned for ad requests made,
+   * when the app volume is reported as muted or set to a value of 0. This may restrict a subset of the broader video ads pool from serving.
+   *
+   * @see https://developers.google.com/admob/android/global-settings
+   * @since 4.1.1
+   */
+  muted?: boolean;
+}
+
+export interface ApplicationVolumeOptions {
+  /**
+   * If your app has its own volume controls (such as custom music or sound effect volumes),
+   * disclosing app volume to the Google Mobile Ads SDK allows video ads to respect app volume settings.
+   * enable set 0.0 - 1.0, any float allowed.
+   *
+   * @see https://developers.google.com/admob/android/global-settings
+   * @since 4.1.1
+   */
+  volume?: 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1.0;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,10 +1,13 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { AdMobPlugin } from '.';
+import type {
+  AdMobPlugin,
+  ApplicationMutedOptions,
+  ApplicationVolumeOptions,
+} from '.';
 import type { AdMobRewardItem } from './reward';
 import type { AdOptions, AdLoadInfo } from './shared';
 import type { TrackingAuthorizationStatusInterface } from './shared/tracking-authorization-status.interface';
-import type { ApplicationMutedOptions, ApplicationVolumeOptions } from '.';
 
 export class AdMobWeb extends WebPlugin implements AdMobPlugin {
   constructor() {

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,6 +27,16 @@ export class AdMobWeb extends WebPlugin implements AdMobPlugin {
     };
   }
 
+  //TODO: setApplicationMuted takes an options object that should probably be logged as well.
+  async setApplicationMuted(): Promise<void> {
+    console.log('setApplicationMuted');
+  }
+
+  //TODO: setApplicationVolume takes an options object that should probably be logged as well.
+  async setApplicationVolume(): Promise<void> {
+    console.log('setApplicationMuted');
+  }
+
   async showBanner(options: AdOptions): Promise<void> {
     console.log('showBanner', options);
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,6 +4,7 @@ import type { AdMobPlugin } from '.';
 import type { AdMobRewardItem } from './reward';
 import type { AdOptions, AdLoadInfo } from './shared';
 import type { TrackingAuthorizationStatusInterface } from './shared/tracking-authorization-status.interface';
+import type { ApplicationMutedOptions, ApplicationVolumeOptions } from '.';
 
 export class AdMobWeb extends WebPlugin implements AdMobPlugin {
   constructor() {
@@ -27,14 +28,12 @@ export class AdMobWeb extends WebPlugin implements AdMobPlugin {
     };
   }
 
-  //TODO: setApplicationMuted takes an options object that should probably be logged as well.
-  async setApplicationMuted(): Promise<void> {
-    console.log('setApplicationMuted');
+  async setApplicationMuted(options: ApplicationMutedOptions): Promise<void> {
+    console.log('setApplicationMuted', options);
   }
 
-  //TODO: setApplicationVolume takes an options object that should probably be logged as well.
-  async setApplicationVolume(): Promise<void> {
-    console.log('setApplicationMuted');
+  async setApplicationVolume(options: ApplicationVolumeOptions): Promise<void> {
+    console.log('setApplicationVolume', options);
   }
 
   async showBanner(options: AdOptions): Promise<void> {


### PR DESCRIPTION
Adds methods for setApplicationMuted and setApplicationVolume, implementing #50. The simplest option to me seemed to be simply exposing the AdMob APIs directly here

I can't really figure out how the tests are setup (and they're barely necessary given the simplicity of these changes), so I'd appreciate if someone else could work those in. 

Otherwise, all tests that passed with version 4.1.0 are working with this PR. Version 4.1.0 had 2 failed tests, ShowInterstitial. Should not try to call show when no Interstitial was prepared, and ShowRewardVideoAd. Should not try to call show when no Reward was prepared. These still fail with this PR (at least on my device), but none of the code related to either of these tests or methods has been changed (ie, not a regression)

Otherwise, I believe I'd done all the stuff with docs properly. There's a slight opportunity for improving the logging on the web code to log the options object that's passed, but that should be a trivial task to someone better acquainted with this library. 