### PR TITLE
chore(ci): Update actions to use node 16

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,20 +10,20 @@ jobs:
   lint:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - run: npm run lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - run: npm run test
       - run: npm run lint
@@ -31,29 +31,29 @@ jobs:
   verify-web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - run: npm run verify:web
 
   verify-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - run: npm run verify:android
 
   verify-ios:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - run: npm run verify:ios

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           node-version: '16'
       - run: npm install
-      - run: npm run test
       - run: npm run lint
 
   verify-web:


### PR DESCRIPTION
Capacitor 5 requires node 16, so I've updated the ci to use node 16
also updated all actions to use v3

removed the test step since there is no test script in the package.json, with v2 it was erroring but not failing the step, with v3 it fails