### PR TITLE
chore(ci): Use java 17

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -40,6 +40,11 @@ jobs:
   verify-android:
     runs-on: ubuntu-latest
     steps:
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Capacitor 5 requires java 17 and android tests is failing because of that
won't fix the tests because they were broken before, but will make them fail where they were failing before