### PR TITLE
Android banner ads, fix center align in fullscreen, landscape mode.

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
@@ -2,10 +2,12 @@ package com.getcapacitor.community.admob.banner;
 
 import android.app.Activity;
 import android.content.Context;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;

--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
@@ -114,10 +114,10 @@ public class BannerExecutor extends Executor {
                 }
                 mAdViewLayoutParams.setMargins(margin, densityMargin, margin, densityMargin);
             } else {
-				int sideMargin = ((int) defaultWidthPixels - adWidth) / 2;
-				if (fullscreen) {
-					sideMargin = (realWidthPixels - adWidth) / 2;
-				}
+                int sideMargin = ((int) defaultWidthPixels - adWidth) / 2;
+                if (fullscreen) {
+                    sideMargin = (realWidthPixels - adWidth) / 2;
+                }
                 mAdViewLayoutParams.setMargins(sideMargin, densityMargin, sideMargin, densityMargin);
             }
 


### PR DESCRIPTION
This fix, considers the device full width during full screen landscape mode, to correctly align the banner ad to the center.

Issue #270 