### PR TITLE
chore: fix fmt script and run it

### DIFF
--- a/ios/Plugin/Banner/BannerExecutor.swift
+++ b/ios/Plugin/Banner/BannerExecutor.swift
@@ -3,7 +3,7 @@ import Capacitor
 import GoogleMobileAds
 
 class BannerExecutor: NSObject, GADBannerViewDelegate {
-    public weak var plugin: AdMob?
+    weak var plugin: AdMob?
     var bannerView: GADBannerView!
 
     func showBanner(_ call: CAPPluginCall, _ request: GADRequest, _ adUnitID: String) {
@@ -144,7 +144,7 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
     }
 
     /// Tells the delegate an ad request loaded an ad.
-    public func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
+    func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
         NSLog("bannerViewDidReceiveAd")
 
         self.plugin?.notifyListeners(BannerAdPluginEvents.SizeChanged.rawValue, data: [
@@ -155,8 +155,8 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
     }
 
     /// Tells the delegate an ad request failed.
-    public func bannerView(_ bannerView: GADBannerView,
-                           didFailToReceiveAdWithError error: Error) {
+    func bannerView(_ bannerView: GADBannerView,
+                    didFailToReceiveAdWithError error: Error) {
         NSLog("bannerView:didFailToReceiveAdWithError: \(error.localizedDescription)")
         self.removeBannerViewToView()
         self.plugin?.notifyListeners(BannerAdPluginEvents.SizeChanged.rawValue, data: [
@@ -169,18 +169,18 @@ class BannerExecutor: NSObject, GADBannerViewDelegate {
         ])
     }
 
-    public func bannerViewDidRecordImpression(_ bannerView: GADBannerView) {
+    func bannerViewDidRecordImpression(_ bannerView: GADBannerView) {
         self.plugin?.notifyListeners(BannerAdPluginEvents.AdImpression.rawValue, data: [:])
     }
 
     /// Tells the delegate that a full-screen view will be presented in response
     /// to the user clicking on an ad.
-    public func bannerViewWillPresentScreen(_ bannerView: GADBannerView) {
+    func bannerViewWillPresentScreen(_ bannerView: GADBannerView) {
         self.plugin?.notifyListeners(BannerAdPluginEvents.Opened.rawValue, data: [:])
     }
 
     /// Tells the delegate that the full-screen view will be dismissed.
-    public func bannerViewWillDismissScreen(_ bannerView: GADBannerView) {
+    func bannerViewWillDismissScreen(_ bannerView: GADBannerView) {
         self.plugin?.notifyListeners(BannerAdPluginEvents.Closed.rawValue, data: [:])
     }
 }

--- a/ios/Plugin/Consent/ConsentExecutor.swift
+++ b/ios/Plugin/Consent/ConsentExecutor.swift
@@ -4,7 +4,7 @@ import GoogleMobileAds
 import UserMessagingPlatform
 
 class ConsentExecutor: NSObject {
-    public weak var plugin: AdMob?
+    weak var plugin: AdMob?
 
     func requestConsentInfo(_ call: CAPPluginCall, _ debugGeography: Int, _ testDeviceIdentifiers: [String], _ tagForUnderAgeOfConsent: Bool) {
         let parameters = UMPRequestParameters()

--- a/ios/Plugin/Interstitial/AdInterstitialExecutor.swift
+++ b/ios/Plugin/Interstitial/AdInterstitialExecutor.swift
@@ -3,7 +3,7 @@ import Capacitor
 import GoogleMobileAds
 
 class AdInterstitialExecutor: NSObject, GADFullScreenContentDelegate {
-    public weak var plugin: AdMob?
+    weak var plugin: AdMob?
     var interstitial: GADInterstitialAd!
 
     func prepareInterstitial(_ call: CAPPluginCall, _ request: GADRequest, _ adUnitID: String) {
@@ -45,7 +45,7 @@ class AdInterstitialExecutor: NSObject, GADFullScreenContentDelegate {
         }
     }
 
-    public func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         NSLog("InterstitialFullScreenDelegate Ad failed to present full screen content with error \(error.localizedDescription).")
         self.plugin?.notifyListeners(InterstitialAdPluginEvents.FailedToShow.rawValue, data: [
             "code": 0,
@@ -53,12 +53,12 @@ class AdInterstitialExecutor: NSObject, GADFullScreenContentDelegate {
         ])
     }
 
-    public func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         NSLog("InterstitialFullScreenDelegate Ad did present full screen content.")
         self.plugin?.notifyListeners(InterstitialAdPluginEvents.Showed.rawValue, data: [:])
     }
 
-    public func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         NSLog("InterstitialFullScreenDelegate Ad did dismiss full screen content.")
         self.plugin?.notifyListeners(InterstitialAdPluginEvents.Dismissed.rawValue, data: [:])
     }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -59,7 +59,7 @@ public class AdMob: CAPPlugin {
 
     @objc func setApplicationVolume(_ call: CAPPluginCall) {
         if var volume = call.getFloat("volume") {
-            //Clamp volumes.
+            // Clamp volumes.
             if volume < 0.0 {volume = 0.0} else if volume > 1.0 {volume = 1.0}
 
             GADMobileAds.sharedInstance().applicationVolume = volume

--- a/ios/Plugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Plugin/Rewarded/AdRewardExecutor.swift
@@ -3,7 +3,7 @@ import Capacitor
 import GoogleMobileAds
 
 class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
-    public weak var plugin: AdMob?
+    weak var plugin: AdMob?
     var rewardedAd: GADRewardedAd!
 
     func prepareRewardVideoAd(_ call: CAPPluginCall, _ request: GADRequest, _ adUnitID: String) {
@@ -66,7 +66,7 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
         }
     }
 
-    public func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         NSLog("RewardFullScreenDelegate Ad failed to present full screen content with error \(error.localizedDescription).")
         self.plugin?.notifyListeners(RewardAdPluginEvents.FailedToShow.rawValue, data: [
             "code": 0,
@@ -74,12 +74,12 @@ class AdRewardExecutor: NSObject, GADFullScreenContentDelegate {
         ])
     }
 
-    public func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adWillPresentFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         NSLog("RewardFullScreenDelegate Ad did present full screen content.")
         self.plugin?.notifyListeners(RewardAdPluginEvents.Showed.rawValue, data: [:])
     }
 
-    public func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
         NSLog("RewardFullScreenDelegate Ad did dismiss full screen content.")
         self.plugin?.notifyListeners(RewardAdPluginEvents.Dismissed.rawValue, data: [:])
     }

--- a/ios/PluginTests/PluginTests.swift
+++ b/ios/PluginTests/PluginTests.swift
@@ -4,16 +4,6 @@ import Capacitor
 
 class PluginTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     func testEcho() {
         XCTAssertEqual(1, 1)
         // This is an example of a functional test case for a plugin.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- autocorrect --format",
+    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
     "eslint": "eslint src/. --ext ts",
     "prettier": "prettier \"{src/*.ts,**/*.java}\"",
     "swiftlint": "node-swiftlint",
@@ -81,7 +81,7 @@
       "git add"
     ],
     "*.swift": [
-      "npm run swiftlint -- autocorrect --format",
+      "npm run swiftlint -- --fix --format",
       "git add"
     ]
   },


### PR DESCRIPTION
`autocorrect` was replaced by `--fix` long ago, so fmt and the commit hook were doing nothing on swift files.

This PR fix the fmt and swift files hook scripts and run fmt to apply missing changes.