### PR TITLE
fix: use proper Capacitor 6 SPM dependency syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["AdMobPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "6.0.0"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "6.0.0"),
         .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", branch: "main")
     ],
     targets: [


### PR DESCRIPTION
branch 6.0.0 doesn't exist, the proper way of setting the version is using `from`.

on the Capacitor 7 PR you sent it's been taken care of by the migration tool, but in case you want to fix it for the Capacitor 6 version too.