### PR TITLE
Fix misleading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,6 @@ requestTrackingAuthorization() => Promise<void>
 ```
 
 request requestTrackingAuthorization (iOS &gt;14).
-This is deprecated method. We recommend UMP Consent.
 
 **Since:** 5.2.0
 


### PR DESCRIPTION
~~NOTE: I only deleted [LOC 414](https://github.com/capacitor-community/admob/blob/master/README.md?plain=1#L414) but the commit is strangely showing 993 additions and 991 deletions. I'm guessing this is issues with Windows/macOS/Linux end-of-line (EOL).~~

[requestTrackingAuthorization](https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/requesttrackingauthorization(completionhandler:)) is **NOT DEPRECATED** and has no direct relation to Google's UMP.

Here's a better explanation by ChatGPT:

### ATT (Apple’s App Tracking Transparency)
- **Who requires it**: Apple
- **API**: `ATTrackingManager.requestTrackingAuthorization(completionHandler:)`
- **What it covers**:
    - Whether your app can access the **IDFA** (Identifier for Advertisers) for personalized ads.
    - Whether you can track users across **apps and websites** on iOS.
- **Scope**: iOS devices only.
- **Applies regardless of ads provider** (AdMob, Facebook, custom SDKs).
- **System-level prompt** – Apple controls the UI and you can only show it once.

### UMP (Google’s User Messaging Platform)
- **Who requires it**: Google (to comply with **GDPR**, **ePrivacy**, and other privacy laws in certain regions like the EU/EEA, UK, etc.)
- **SDK**: Google’s UMP SDK
- **What it covers**:
    - Consent for **personalized ads** (vs non-personalized ads).
    - Consent for use of **cookies and local storage**.
    - Consent for sharing user data with **Google and ad partners**.
- **Scope**: Worldwide, but especially mandatory in the EU/UK.
- **UI is customizable** – Google provides templates, but you can style and manage flows.

### Relationship Between ATT & UMP
- They are **independent**:
    - **ATT** = Apple’s requirement for iOS tracking.
    - **UMP** = Google’s requirement for privacy law compliance.
- But in practice, if you’re showing **AdMob ads in iOS apps**:
    - You may need **both**:
        - **ATT prompt** → controls whether you get the IDFA.
        - **UMP consent form** → controls whether you can serve personalized ads legally in regions like the EU.
- They **work together** like this:
    1. Ask for UMP consent (GDPR/ePrivacy compliance).
    2. Then, if needed, request ATT permission to access IDFA.
    3. Configure AdMob to serve ads based on both sets of responses.
    
### ✅ In short:
- **ATT ≠ UMP**.
- **ATT = Apple’s system-level tracking permission**.
- **UMP = Google’s consent for personalized ads (legal compliance, mainly in EU)**.
- If you use AdMob in iOS apps, you usually need to integrate **both**.