### PR TITLE
refactor(ios): Remove iOS 11 code check in BannerExecutor.swift

### DIFF
--- a/ios/Sources/AdMobPlugin/Banner/BannerExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Banner/BannerExecutor.swift
@@ -40,11 +40,7 @@ class BannerExecutor: NSObject, BannerViewDelegate {
                 let frame = { () -> CGRect in
                     // Here safe area is taken into account, hence the view frame is used
                     // after the view has been laid out.
-                    if #available(iOS 11.0, *) {
-                        return rootViewController.view.frame.inset(by: rootViewController.view.safeAreaInsets)
-                    } else {
-                        return rootViewController.view.frame
-                    }
+                    return rootViewController.view.frame.inset(by: rootViewController.view.safeAreaInsets)
                 }()
                 let viewWidth = frame.size.width
                 bannerSize = currentOrientationAnchoredAdaptiveBanner(width: viewWidth)


### PR DESCRIPTION
The plugin supports iOS 14+, so the check is always true so the check and the else code can be removed