### PR TITLE
docs: remove original misleading documentation

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -31,7 +31,6 @@ export interface AdMobPlugin extends AdMobDefinitions {
 
   /**
    * request requestTrackingAuthorization (iOS >14).
-   * This is deprecated method. We recommend UMP Consent.
    *
    * @see https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/3547038-trackingauthorizationstatus
    * @since 5.2.0


### PR DESCRIPTION
In https://github.com/capacitor-community/admob/pull/369 this line was removed from the `README.md` file, but it's autogenerated from the types, so it gets re added on every `npm run build`.

This PR removes the line from the types so it doesn't get added.