### PR TITLE
(feat) Support impression-level ad revenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
 * [`addListener(BannerAdPluginEvents.Opened, ...)`](#addlistenerbanneradplugineventsopened-)
 * [`addListener(BannerAdPluginEvents.Closed, ...)`](#addlistenerbanneradplugineventsclosed-)
 * [`addListener(BannerAdPluginEvents.AdImpression, ...)`](#addlistenerbanneradplugineventsadimpression-)
+* [`addListener(BannerAdPluginEvents.AdPaid, ...)`](#addlistenerbanneradplugineventsadpaid-)
 * [`requestConsentInfo(...)`](#requestconsentinfo)
 * [`showPrivacyOptionsForm()`](#showprivacyoptionsform)
 * [`showConsentForm()`](#showconsentform)
@@ -815,6 +816,22 @@ Unimplemented
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
 **Since:** 3.0.0
+
+--------------------
+
+
+### addListener(BannerAdPluginEvents.AdPaid, ...)
+
+```typescript
+addListener(eventName: BannerAdPluginEvents.AdPaid, listenerFunc: (data: AdMobRevenueData) => void) => Promise<PluginListenerHandle>
+```
+
+| Param              | Type                                                                             |
+| ------------------ | -------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#banneradpluginevents">BannerAdPluginEvents.AdPaid</a></code>     |
+| **`listenerFunc`** | <code>(data: <a href="#admobrevenuedata">AdMobRevenueData</a>) =&gt; void</code> |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
 --------------------
 
@@ -1561,6 +1578,7 @@ From T, pick a set of properties whose keys are in the union K
 | **`Opened`**       | <code>"bannerAdOpened"</code>       | Open "Adsense" Event after user click banner                                                           |
 | **`Closed`**       | <code>"bannerAdClosed"</code>       | Close "Adsense" Event after user click banner                                                          |
 | **`AdImpression`** | <code>"bannerAdImpression"</code>   | Similarly, this method should be called when an impression is recorded for the ad by the mediated SDK. |
+| **`AdPaid`**       | <code>"bannerAdPaid"</code>         |                                                                                                        |
 
 
 #### AdmobConsentStatus

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
 * [`addListener(AppOpenAdPluginEvents.Opened, ...)`](#addlistenerappopenadplugineventsopened-)
 * [`addListener(AppOpenAdPluginEvents.Closed, ...)`](#addlistenerappopenadplugineventsclosed-)
 * [`addListener(AppOpenAdPluginEvents.FailedToShow, ...)`](#addlistenerappopenadplugineventsfailedtoshow-)
+* [`addListener(AppOpenAdPluginEvents.AdImpression, ...)`](#addlistenerappopenadplugineventsadimpression-)
 * [`showBanner(...)`](#showbanner)
 * [`hideBanner()`](#hidebanner)
 * [`resumeBanner()`](#resumebanner)
@@ -400,6 +401,7 @@ AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
 * [`addListener(InterstitialAdPluginEvents.Dismissed, ...)`](#addlistenerinterstitialadplugineventsdismissed-)
 * [`addListener(InterstitialAdPluginEvents.FailedToShow, ...)`](#addlistenerinterstitialadplugineventsfailedtoshow-)
 * [`addListener(InterstitialAdPluginEvents.Showed, ...)`](#addlistenerinterstitialadplugineventsshowed-)
+* [`addListener(InterstitialAdPluginEvents.AdImpression, ...)`](#addlistenerinterstitialadplugineventsadimpression-)
 * [`prepareRewardVideoAd(...)`](#preparerewardvideoad)
 * [`showRewardVideoAd()`](#showrewardvideoad)
 * [`addListener(RewardAdPluginEvents.FailedToLoad, ...)`](#addlistenerrewardadplugineventsfailedtoload-)
@@ -408,6 +410,7 @@ AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
 * [`addListener(RewardAdPluginEvents.Dismissed, ...)`](#addlistenerrewardadplugineventsdismissed-)
 * [`addListener(RewardAdPluginEvents.FailedToShow, ...)`](#addlistenerrewardadplugineventsfailedtoshow-)
 * [`addListener(RewardAdPluginEvents.Showed, ...)`](#addlistenerrewardadplugineventsshowed-)
+* [`addListener(RewardAdPluginEvents.AdImpression, ...)`](#addlistenerrewardadplugineventsadimpression-)
 * [`prepareRewardInterstitialAd(...)`](#preparerewardinterstitialad)
 * [`showRewardInterstitialAd()`](#showrewardinterstitialad)
 * [`addListener(RewardInterstitialAdPluginEvents.FailedToLoad, ...)`](#addlistenerrewardinterstitialadplugineventsfailedtoload-)
@@ -416,6 +419,7 @@ AdMob.addListener(RewardAdPluginEvents.Rewarded, async () => {
 * [`addListener(RewardInterstitialAdPluginEvents.Dismissed, ...)`](#addlistenerrewardinterstitialadplugineventsdismissed-)
 * [`addListener(RewardInterstitialAdPluginEvents.FailedToShow, ...)`](#addlistenerrewardinterstitialadplugineventsfailedtoshow-)
 * [`addListener(RewardInterstitialAdPluginEvents.Showed, ...)`](#addlistenerrewardinterstitialadplugineventsshowed-)
+* [`addListener(RewardInterstitialAdPluginEvents.AdImpression, ...)`](#addlistenerrewardinterstitialadplugineventsadimpression-)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 * [Enums](#enums)
@@ -619,6 +623,22 @@ addListener(eventName: AppOpenAdPluginEvents.FailedToShow, listenerFunc: (error:
 | ------------------ | ------------------------------------------------------------------------------------ |
 | **`eventName`**    | <code><a href="#appopenadpluginevents">AppOpenAdPluginEvents.FailedToShow</a></code> |
 | **`listenerFunc`** | <code>(error: <a href="#admoberror">AdMobError</a>) =&gt; void</code>                |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener(AppOpenAdPluginEvents.AdImpression, ...)
+
+```typescript
+addListener(eventName: AppOpenAdPluginEvents.AdImpression, listenerFunc: (data: AdMobRevenueData) => void) => Promise<PluginListenerHandle>
+```
+
+| Param              | Type                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| **`eventName`**    | <code><a href="#appopenadpluginevents">AppOpenAdPluginEvents.AdImpression</a></code> |
+| **`listenerFunc`** | <code>(data: <a href="#admobrevenuedata">AdMobRevenueData</a>) =&gt; void</code>     |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
@@ -971,6 +991,22 @@ addListener(eventName: InterstitialAdPluginEvents.Showed, listenerFunc: () => vo
 --------------------
 
 
+### addListener(InterstitialAdPluginEvents.AdImpression, ...)
+
+```typescript
+addListener(eventName: InterstitialAdPluginEvents.AdImpression, listenerFunc: (data: AdMobRevenueData) => void) => Promise<PluginListenerHandle>
+```
+
+| Param              | Type                                                                                           |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#interstitialadpluginevents">InterstitialAdPluginEvents.AdImpression</a></code> |
+| **`listenerFunc`** | <code>(data: <a href="#admobrevenuedata">AdMobRevenueData</a>) =&gt; void</code>               |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
 ### prepareRewardVideoAd(...)
 
 ```typescript
@@ -1095,6 +1131,22 @@ addListener(eventName: RewardAdPluginEvents.Showed, listenerFunc: () => void) =>
 | ------------------ | ---------------------------------------------------------------------------- |
 | **`eventName`**    | <code><a href="#rewardadpluginevents">RewardAdPluginEvents.Showed</a></code> |
 | **`listenerFunc`** | <code>() =&gt; void</code>                                                   |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener(RewardAdPluginEvents.AdImpression, ...)
+
+```typescript
+addListener(eventName: RewardAdPluginEvents.AdImpression, listenerFunc: (data: AdMobRevenueData) => void) => Promise<PluginListenerHandle>
+```
+
+| Param              | Type                                                                               |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#rewardadpluginevents">RewardAdPluginEvents.AdImpression</a></code> |
+| **`listenerFunc`** | <code>(data: <a href="#admobrevenuedata">AdMobRevenueData</a>) =&gt; void</code>   |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 
@@ -1231,6 +1283,22 @@ addListener(eventName: RewardInterstitialAdPluginEvents.Showed, listenerFunc: ()
 --------------------
 
 
+### addListener(RewardInterstitialAdPluginEvents.AdImpression, ...)
+
+```typescript
+addListener(eventName: RewardInterstitialAdPluginEvents.AdImpression, listenerFunc: (data: AdMobRevenueData) => void) => Promise<PluginListenerHandle>
+```
+
+| Param              | Type                                                                                                       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **`eventName`**    | <code><a href="#rewardinterstitialadpluginevents">RewardInterstitialAdPluginEvents.AdImpression</a></code> |
+| **`listenerFunc`** | <code>(data: <a href="#admobrevenuedata">AdMobRevenueData</a>) =&gt; void</code>                           |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -1289,6 +1357,18 @@ https://developers.google.com/android/reference/com/google/android/gms/ads/AdErr
 | ------------- | ------------------- | -------------------------------------- |
 | **`code`**    | <code>number</code> | Gets the error's code.                 |
 | **`message`** | <code>string</code> | Gets the message describing the error. |
+
+
+#### AdMobRevenueData
+
+| Prop               | Type                                                          |
+| ------------------ | ------------------------------------------------------------- |
+| **`adUnitId`**     | <code>string</code>                                           |
+| **`valueMicros`**  | <code>number</code>                                           |
+| **`currencyCode`** | <code>string</code>                                           |
+| **`precision`**    | <code><a href="#advalueprecision">AdValuePrecision</a></code> |
+| **`networkName`**  | <code>string</code>                                           |
+| **`impressionId`** | <code>string</code>                                           |
 
 
 #### BannerAdOptions
@@ -1436,6 +1516,17 @@ From T, pick a set of properties whose keys are in the union K
 | **`Opened`**       | <code>'appOpenAdOpened'</code>       |
 | **`Closed`**       | <code>'appOpenAdClosed'</code>       |
 | **`FailedToShow`** | <code>'appOpenAdFailedToShow'</code> |
+| **`AdImpression`** | <code>'appOpenAdImpression'</code>   |
+
+
+#### AdValuePrecision
+
+| Members                 | Value          |
+| ----------------------- | -------------- |
+| **`Unknown`**           | <code>0</code> |
+| **`Estimated`**         | <code>1</code> |
+| **`PublisherProvided`** | <code>2</code> |
+| **`Precise`**           | <code>3</code> |
 
 
 #### BannerAdSize
@@ -1511,6 +1602,7 @@ From T, pick a set of properties whose keys are in the union K
 | **`Showed`**       | <code>'interstitialAdShowed'</code>       | Emits when the Interstitial ad is visible to the user                                  |
 | **`FailedToShow`** | <code>'interstitialAdFailedToShow'</code> | Emits when the Interstitial ad is failed to show                                       |
 | **`Dismissed`**    | <code>'interstitialAdDismissed'</code>    | Emits when the Interstitial ad is not visible to the user anymore.                     |
+| **`AdImpression`** | <code>'interstitialAdImpression'</code>   | Emits when an impression-level ad revenue event is recorded                            |
 
 
 #### RewardAdPluginEvents
@@ -1523,6 +1615,7 @@ From T, pick a set of properties whose keys are in the union K
 | **`FailedToShow`** | <code>'onRewardedVideoAdFailedToShow'</code> | Emits when the AdReward video is failed to show                                                                                                                                                                                                                                                                                                        |
 | **`Dismissed`**    | <code>'onRewardedVideoAdDismissed'</code>    | Emits when the AdReward video is not visible to the user anymore. **Important**: This has nothing to do with the reward it self. This event will emits in this two cases: 1. The user starts the video ad but close it before the reward emit. 2. The user start the video and see it until end, then gets the reward and after that the ad is closed. |
 | **`Rewarded`**     | <code>'onRewardedVideoAdReward'</code>       | Emits when user get rewarded from AdReward                                                                                                                                                                                                                                                                                                             |
+| **`AdImpression`** | <code>'onRewardedVideoAdImpression'</code>   | Emits when an impression-level ad revenue event is recorded                                                                                                                                                                                                                                                                                            |
 
 
 #### RewardInterstitialAdPluginEvents
@@ -1535,6 +1628,7 @@ From T, pick a set of properties whose keys are in the union K
 | **`FailedToShow`** | <code>'onRewardedInterstitialAdFailedToShow'</code> | Emits when the AdReward video is failed to show                                                                                                                                                                                                                                                                                                        |
 | **`Dismissed`**    | <code>'onRewardedInterstitialAdDismissed'</code>    | Emits when the AdReward video is not visible to the user anymore. **Important**: This has nothing to do with the reward it self. This event will emits in this two cases: 1. The user starts the video ad but close it before the reward emit. 2. The user start the video and see it until end, then gets the reward and after that the ad is closed. |
 | **`Rewarded`**     | <code>'onRewardedInterstitialAdReward'</code>       | Emits when user get rewarded from AdReward                                                                                                                                                                                                                                                                                                             |
+| **`AdImpression`** | <code>'onRewardedInterstitialAdImpression'</code>   | Emits when an impression-level ad revenue event is recorded                                                                                                                                                                                                                                                                                            |
 
 </docgen-api>
 

--- a/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdManager.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.AdValue
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.appopen.AppOpenAd
 
@@ -17,7 +18,7 @@ class AppOpenAdManager(val adUnitId: String) {
     val isAdLoaded: Boolean
         get() = appOpenAd != null
 
-    fun loadAd(context: Context, onLoaded: () -> Unit, onFailed: (LoadAdError?) -> Unit) {
+    fun loadAd(context: Context, onLoaded: () -> Unit, onFailed: (LoadAdError?) -> Unit, onPaidEvent: (AdValue, String, String) -> Unit) {
         if (appOpenAd != null) {
             onLoaded()
             return
@@ -40,6 +41,11 @@ class AppOpenAdManager(val adUnitId: String) {
                 override fun onAdLoaded(ad: AppOpenAd) {
                     appOpenAd = ad
                     isLoadingAd = false
+                    ad.setOnPaidEventListener { adValue ->
+                        val networkName = ad.responseInfo?.mediationAdapterClassName ?: ""
+                        val impressionId = ad.responseInfo?.responseId ?: ""
+                        onPaidEvent(adValue, networkName, impressionId)
+                    }
                     onLoaded()
                 }
 

--- a/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPlugin.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPlugin.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.admob.models.AdMobPluginError
+import com.getcapacitor.community.admob.models.AdMobRevenueData
 
 class AppOpenAdPlugin {
 
@@ -56,6 +57,10 @@ class AppOpenAdPlugin {
                     val errorCode = loadAdError?.code ?: -1
                     notifier.notify(AppOpenAdPluginEvents.FailedToLoad, AdMobPluginError(errorCode, errorMessage))
                     call.reject(errorMessage)
+                },
+                onPaidEvent = { adValue, networkName, impressionId ->
+                    val revenueData = AdMobRevenueData(adValue, adUnitId, networkName, impressionId)
+                    notifier.notify(AppOpenAdPluginEvents.AdImpression, revenueData)
                 }
             )
         }

--- a/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPluginEvents.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPluginEvents.kt
@@ -6,4 +6,5 @@ object AppOpenAdPluginEvents {
     const val Opened = "appOpenAdOpened"
     const val Closed = "appOpenAdClosed"
     const val FailedToShow = "appOpenAdFailedToShow"
+    const val AdImpression = "appOpenAdImpression"
 }

--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerAdPluginEvents.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerAdPluginEvents.kt
@@ -8,4 +8,5 @@ enum class BannerAdPluginEvents(val webEventName: String) {
     Loaded("bannerAdLoaded"),
     Clicked("bannerAdClicked"),
     AdImpression("bannerAdImpression"),
+    AdPaid("bannerAdPaid"),
 }

--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
@@ -18,6 +18,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.community.admob.helpers.AdViewIdHelper;
 import com.getcapacitor.community.admob.helpers.RequestHelper;
 import com.getcapacitor.community.admob.models.AdMobPluginError;
+import com.getcapacitor.community.admob.models.AdMobRevenueData;
 import com.getcapacitor.community.admob.models.AdOptions;
 import com.getcapacitor.community.admob.models.Executor;
 import com.google.android.gms.ads.AdListener;
@@ -287,14 +288,21 @@ public class BannerExecutor extends Executor {
                             notifyListeners(BannerAdPluginEvents.Closed.getWebEventName(), emptyObject);
                             super.onAdClosed();
                         }
-
-                        @Override
-                        public void onAdImpression() {
-                            notifyListeners(BannerAdPluginEvents.AdImpression.getWebEventName(), emptyObject);
-                            super.onAdImpression();
-                        }
                     }
                 );
+
+                mAdView.setOnPaidEventListener((adValue) -> {
+                    String networkName = "";
+                    String impressionId = "";
+                    if (mAdView.getResponseInfo() != null) {
+                        networkName = mAdView.getResponseInfo().getMediationAdapterClassName();
+                        if (networkName == null) networkName = "";
+                        impressionId = mAdView.getResponseInfo().getResponseId();
+                        if (impressionId == null) impressionId = "";
+                    }
+                    AdMobRevenueData revenueData = new AdMobRevenueData(adValue, mAdView.getAdUnitId(), networkName, impressionId);
+                    notifyListeners(BannerAdPluginEvents.AdImpression.getWebEventName(), revenueData);
+                });
 
                 // Add AdViewLayout top of the WebView
                 mViewGroup.addView(mAdViewLayout);

--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
@@ -288,6 +288,12 @@ public class BannerExecutor extends Executor {
                             notifyListeners(BannerAdPluginEvents.Closed.getWebEventName(), emptyObject);
                             super.onAdClosed();
                         }
+
+                        @Override
+                        public void onAdImpression() {
+                            notifyListeners(BannerAdPluginEvents.AdImpression.getWebEventName(), emptyObject);
+                            super.onAdImpression();
+                        }
                     }
                 );
 
@@ -301,7 +307,7 @@ public class BannerExecutor extends Executor {
                         if (impressionId == null) impressionId = "";
                     }
                     AdMobRevenueData revenueData = new AdMobRevenueData(adValue, mAdView.getAdUnitId(), networkName, impressionId);
-                    notifyListeners(BannerAdPluginEvents.AdImpression.getWebEventName(), revenueData);
+                    notifyListeners(BannerAdPluginEvents.AdPaid.getWebEventName(), revenueData);
                 });
 
                 // Add AdViewLayout top of the WebView

--- a/android/src/main/java/com/getcapacitor/community/admob/interstitial/InterstitialAdCallbackAndListeners.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/interstitial/InterstitialAdCallbackAndListeners.kt
@@ -4,6 +4,7 @@ import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.admob.helpers.FullscreenPluginCallback
 import com.getcapacitor.community.admob.models.AdMobPluginError
+import com.getcapacitor.community.admob.models.AdMobRevenueData
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
@@ -19,6 +20,14 @@ object InterstitialAdCallbackAndListeners {
                 val immersiveMode = call.getBoolean("immersiveMode")
                 ad.fullScreenContentCallback = FullscreenPluginCallback(InterstitialAdPluginPluginEvent, notifyListenersFunction)
                 ad.setImmersiveMode(immersiveMode ?: false)
+
+                ad.setOnPaidEventListener { adValue ->
+                    val responseInfo = ad.responseInfo
+                    val networkName = responseInfo?.mediationAdapterClassName ?: ""
+                    val impressionId = responseInfo?.responseId ?: ""
+                    val revenueData = AdMobRevenueData(adValue, ad.adUnitId, networkName, impressionId)
+                    notifyListenersFunction.accept(InterstitialAdPluginPluginEvent.AdImpression, revenueData)
+                }
 
                 AdInterstitialExecutor.interstitialAd = ad
 

--- a/android/src/main/java/com/getcapacitor/community/admob/interstitial/InterstitialAdPluginPluginEvent.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/interstitial/InterstitialAdPluginPluginEvent.kt
@@ -8,4 +8,5 @@ object InterstitialAdPluginPluginEvent: LoadPluginEventNames {
     override val Showed = "interstitialAdShowed"
     override val FailedToShow = "interstitialAdFailedToShow"
     override val Dismissed = "interstitialAdDismissed"
+    const val AdImpression = "interstitialAdImpression"
 }

--- a/android/src/main/java/com/getcapacitor/community/admob/models/AdMobRevenueData.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/models/AdMobRevenueData.kt
@@ -1,0 +1,15 @@
+package com.getcapacitor.community.admob.models
+
+import com.getcapacitor.JSObject
+import com.google.android.gms.ads.AdValue
+
+class AdMobRevenueData(adValue: AdValue, adUnitId: String, networkName: String, impressionId: String) : JSObject() {
+    init {
+        put("adUnitId", adUnitId)
+        put("valueMicros", adValue.valueMicros)
+        put("currencyCode", adValue.currencyCode)
+        put("precision", adValue.precisionType)
+        put("networkName", networkName)
+        put("impressionId", impressionId)
+    }
+}

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/RewardAdPluginEvents.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/RewardAdPluginEvents.kt
@@ -9,4 +9,5 @@ object RewardAdPluginEvents: LoadPluginEventNames {
     override val Showed = "onRewardedVideoAdShowed"
     override val FailedToShow = "onRewardedVideoAdFailedToShow"
     override val Dismissed = "onRewardedVideoAdDismissed"
+    const val AdImpression = "onRewardedVideoAdImpression"
 }

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/RewardedAdCallbackAndListeners.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/RewardedAdCallbackAndListeners.kt
@@ -4,6 +4,7 @@ import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.admob.helpers.FullscreenPluginCallback
 import com.getcapacitor.community.admob.models.AdMobPluginError
+import com.getcapacitor.community.admob.models.AdMobRevenueData
 import com.getcapacitor.community.admob.models.AdOptions
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.OnUserEarnedRewardListener
@@ -34,6 +35,14 @@ object RewardedAdCallbackAndListeners {
                 AdRewardExecutor.mRewardedAd = ad
                 AdRewardExecutor.mRewardedAd.fullScreenContentCallback = FullscreenPluginCallback(
                         RewardAdPluginEvents, notifyListenersFunction)
+
+                ad.setOnPaidEventListener { adValue ->
+                    val responseInfo = ad.responseInfo
+                    val networkName = responseInfo?.mediationAdapterClassName ?: ""
+                    val impressionId = responseInfo?.responseId ?: ""
+                    val revenueData = AdMobRevenueData(adValue, ad.adUnitId, networkName, impressionId)
+                    notifyListenersFunction.accept(RewardAdPluginEvents.AdImpression, revenueData)
+                }
 
                 if(adOptions.ssvInfo.hasInfo){
                     val ssvOptions = ServerSideVerificationOptions.Builder()

--- a/android/src/main/java/com/getcapacitor/community/admob/rewardedinterstitial/RewardInterstitialAdPluginEvents.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewardedinterstitial/RewardInterstitialAdPluginEvents.kt
@@ -9,4 +9,5 @@ object RewardInterstitialAdPluginEvents: LoadPluginEventNames {
     override val Showed = "onRewardedInterstitialAdShowed"
     override val FailedToShow = "onRewardedInterstitialAdFailedToShow"
     override val Dismissed = "onRewardedInterstitialAdDismissed"
+    const val AdImpression = "onRewardedInterstitialAdImpression"
 }

--- a/android/src/main/java/com/getcapacitor/community/admob/rewardedinterstitial/RewardedInterstitialAdCallbackAndListeners.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewardedinterstitial/RewardedInterstitialAdCallbackAndListeners.kt
@@ -4,6 +4,7 @@ import com.getcapacitor.JSObject
 import com.getcapacitor.PluginCall
 import com.getcapacitor.community.admob.helpers.FullscreenPluginCallback
 import com.getcapacitor.community.admob.models.AdMobPluginError
+import com.getcapacitor.community.admob.models.AdMobRevenueData
 import com.getcapacitor.community.admob.models.AdOptions
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.OnUserEarnedRewardListener
@@ -30,6 +31,14 @@ object RewardedInterstitialAdCallbackAndListeners {
                 AdRewardInterstitialExecutor.mRewardedInterstitialAd = ad
                 AdRewardInterstitialExecutor.mRewardedInterstitialAd.fullScreenContentCallback = FullscreenPluginCallback(
                         RewardInterstitialAdPluginEvents, notifyListenersFunction)
+
+                ad.setOnPaidEventListener { adValue ->
+                    val responseInfo = ad.responseInfo
+                    val networkName = responseInfo?.mediationAdapterClassName ?: ""
+                    val impressionId = responseInfo?.responseId ?: ""
+                    val revenueData = AdMobRevenueData(adValue, ad.adUnitId, networkName, impressionId)
+                    notifyListenersFunction.accept(RewardInterstitialAdPluginEvents.AdImpression, revenueData)
+                }
 
                 val adInfo = JSObject()
                 adInfo.put("adUnitId", ad.adUnitId)

--- a/android/src/test/java/com/getcapacitor/community/admob/interstitial/InterstitialAdStub.kt
+++ b/android/src/test/java/com/getcapacitor/community/admob/interstitial/InterstitialAdStub.kt
@@ -10,6 +10,7 @@ internal class InterstitialAdStub: InterstitialAd() {
 
     private var immersiveMode = false;
     private var fullScreenContentCallback: FullScreenContentCallback? = null
+    private var onPaidEventListener: OnPaidEventListener? = null
 
     override fun getAdUnitId(): String {
         return "adUnit"
@@ -36,11 +37,11 @@ internal class InterstitialAdStub: InterstitialAd() {
     }
 
     override fun setOnPaidEventListener(p0: OnPaidEventListener?) {
-        TODO("Not yet implemented")
+        onPaidEventListener = p0
     }
 
     override fun getOnPaidEventListener(): OnPaidEventListener? {
-        TODO("Not yet implemented")
+        return onPaidEventListener
     }
 
     override fun getPlacementId(): Long {

--- a/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdManager.swift
+++ b/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdManager.swift
@@ -35,8 +35,8 @@ import UIKit
                     self.isLoadingAd = false
                     self.appOpenAd = ad
                     ad.paidEventHandler = { adValue in
-                        let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                        let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                        let networkName = ad.responseInfo.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                        let impressionId = ad.responseInfo.responseIdentifier ?? ""
                         onPaidEvent(
                             adValue.value.int64Value,
                             adValue.currencyCode,

--- a/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdManager.swift
+++ b/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdManager.swift
@@ -13,7 +13,7 @@ import UIKit
         self.adUnitId = adUnitId
     }
 
-    public func loadAd(onLoaded: @escaping () -> Void, onFailed: @escaping (Error?) -> Void) {
+    public func loadAd(onLoaded: @escaping () -> Void, onFailed: @escaping (Error?) -> Void, onPaidEvent: @escaping (_ valueMicros: Int64, _ currencyCode: String, _ precision: Int, _ networkName: String, _ impressionId: String) -> Void) {
         if appOpenAd != nil {
             onLoaded()
             return
@@ -34,6 +34,17 @@ import UIKit
                 await MainActor.run {
                     self.isLoadingAd = false
                     self.appOpenAd = ad
+                    ad.paidEventHandler = { adValue in
+                        let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                        let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                        onPaidEvent(
+                            adValue.value.int64Value,
+                            adValue.currencyCode,
+                            adValue.precision.rawValue,
+                            networkName,
+                            impressionId
+                        )
+                    }
                     onLoaded()
                 }
             } catch {

--- a/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPlugin.swift
+++ b/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPlugin.swift
@@ -29,6 +29,15 @@ import UIKit
                     "message": message
                 ])
                 call.reject(message)
+            }, onPaidEvent: { valueMicros, currencyCode, precision, networkName, impressionId in
+                notify(AppOpenAdPluginEvents.AdImpression.rawValue, [
+                    "adUnitId": adUnitId,
+                    "valueMicros": valueMicros,
+                    "currencyCode": currencyCode,
+                    "precision": precision,
+                    "networkName": networkName,
+                    "impressionId": impressionId
+                ])
             })
         }
     }

--- a/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPluginEvents.swift
+++ b/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPluginEvents.swift
@@ -4,4 +4,5 @@ public enum AppOpenAdPluginEvents: String {
     case Opened = "appOpenAdOpened"
     case Closed = "appOpenAdClosed"
     case FailedToShow = "appOpenAdFailedToShow"
+    case AdImpression = "appOpenAdImpression"
 }

--- a/ios/Sources/AdMobPlugin/Banner/BannerAdPluginEvents.swift
+++ b/ios/Sources/AdMobPlugin/Banner/BannerAdPluginEvents.swift
@@ -5,4 +5,5 @@ public enum BannerAdPluginEvents: String {
     case Opened = "bannerAdOpened"
     case Loaded = "bannerAdLoaded"
     case AdImpression = "bannerAdImpression"
+    case AdPaid = "bannerAdPaid"
 }

--- a/ios/Sources/AdMobPlugin/Banner/BannerExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Banner/BannerExecutor.swift
@@ -49,6 +49,20 @@ class BannerExecutor: NSObject, BannerViewDelegate {
             self.bannerView.load(request)
             self.bannerView.delegate = self
 
+            self.bannerView.paidEventHandler = { [weak self] adValue in
+                guard let self = self else { return }
+                let networkName = self.bannerView.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                let impressionId = self.bannerView.responseInfo?.responseIdentifier ?? ""
+                self.plugin?.notifyListeners(BannerAdPluginEvents.AdImpression.rawValue, data: [
+                    "adUnitId": self.bannerView.adUnitID ?? "",
+                    "valueMicros": adValue.value.int64Value,
+                    "currencyCode": adValue.currencyCode,
+                    "precision": adValue.precision.rawValue,
+                    "networkName": networkName,
+                    "impressionId": impressionId
+                ])
+            }
+
             call.resolve([:])
         }
     }
@@ -162,7 +176,6 @@ class BannerExecutor: NSObject, BannerViewDelegate {
     }
 
     func bannerViewDidRecordImpression(_ bannerView: BannerView) {
-        self.plugin?.notifyListeners(BannerAdPluginEvents.AdImpression.rawValue, data: [:])
     }
 
     /// Tells the delegate that a full-screen view will be presented in response

--- a/ios/Sources/AdMobPlugin/Banner/BannerExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Banner/BannerExecutor.swift
@@ -53,7 +53,7 @@ class BannerExecutor: NSObject, BannerViewDelegate {
                 guard let self = self else { return }
                 let networkName = self.bannerView.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
                 let impressionId = self.bannerView.responseInfo?.responseIdentifier ?? ""
-                self.plugin?.notifyListeners(BannerAdPluginEvents.AdImpression.rawValue, data: [
+                self.plugin?.notifyListeners(BannerAdPluginEvents.AdPaid.rawValue, data: [
                     "adUnitId": self.bannerView.adUnitID ?? "",
                     "valueMicros": adValue.value.int64Value,
                     "currencyCode": adValue.currencyCode,
@@ -176,6 +176,7 @@ class BannerExecutor: NSObject, BannerViewDelegate {
     }
 
     func bannerViewDidRecordImpression(_ bannerView: BannerView) {
+        self.plugin?.notifyListeners(BannerAdPluginEvents.AdImpression.rawValue, data: [:])
     }
 
     /// Tells the delegate that a full-screen view will be presented in response

--- a/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
@@ -25,8 +25,8 @@ class AdInterstitialExecutor: NSObject, FullScreenContentDelegate {
                 self.interstitial.fullScreenContentDelegate = self
 
                 self.interstitial.paidEventHandler = { adValue in
-                    let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                    let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                    let networkName = ad?.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad?.responseInfo?.responseIdentifier ?? ""
                     self.plugin?.notifyListeners(InterstitialAdPluginEvents.AdImpression.rawValue, data: [
                         "adUnitId": adUnitID,
                         "valueMicros": adValue.value.int64Value,

--- a/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
@@ -25,8 +25,8 @@ class AdInterstitialExecutor: NSObject, FullScreenContentDelegate {
                 self.interstitial.fullScreenContentDelegate = self
 
                 self.interstitial.paidEventHandler = { adValue in
-                    let networkName = ad?.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                    let impressionId = ad?.responseInfo?.responseIdentifier ?? ""
+                    let networkName = ad?.responseInfo.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad?.responseInfo.responseIdentifier ?? ""
                     self.plugin?.notifyListeners(InterstitialAdPluginEvents.AdImpression.rawValue, data: [
                         "adUnitId": adUnitID,
                         "valueMicros": adValue.value.int64Value,

--- a/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
@@ -23,6 +23,20 @@ class AdInterstitialExecutor: NSObject, FullScreenContentDelegate {
 
                 self.interstitial = ad
                 self.interstitial.fullScreenContentDelegate = self
+
+                self.interstitial.paidEventHandler = { adValue in
+                    let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                    self.plugin?.notifyListeners(InterstitialAdPluginEvents.AdImpression.rawValue, data: [
+                        "adUnitId": adUnitID,
+                        "valueMicros": adValue.value.int64Value,
+                        "currencyCode": adValue.currencyCode,
+                        "precision": adValue.precision.rawValue,
+                        "networkName": networkName,
+                        "impressionId": impressionId
+                    ])
+                }
+
                 self.plugin?.notifyListeners(InterstitialAdPluginEvents.Loaded.rawValue, data: [
                     "adUnitId": adUnitID
                 ])

--- a/ios/Sources/AdMobPlugin/Interstitial/InterstitialAdPluginEvents.swift
+++ b/ios/Sources/AdMobPlugin/Interstitial/InterstitialAdPluginEvents.swift
@@ -4,4 +4,5 @@ public enum InterstitialAdPluginEvents: String {
     case Showed = "interstitialAdShowed"
     case FailedToShow = "interstitialAdFailedToShow"
     case Dismissed = "interstitialAdDismissed"
+    case AdImpression = "interstitialAdImpression"
 }

--- a/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
@@ -42,8 +42,8 @@ class AdRewardExecutor: NSObject, FullScreenContentDelegate {
                 self.rewardedAd?.fullScreenContentDelegate = self
 
                 self.rewardedAd?.paidEventHandler = { adValue in
-                    let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                    let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                    let networkName = ad?.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad?.responseInfo?.responseIdentifier ?? ""
                     self.plugin?.notifyListeners(RewardAdPluginEvents.AdImpression.rawValue, data: [
                         "adUnitId": adUnitID,
                         "valueMicros": adValue.value.int64Value,

--- a/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
@@ -42,8 +42,8 @@ class AdRewardExecutor: NSObject, FullScreenContentDelegate {
                 self.rewardedAd?.fullScreenContentDelegate = self
 
                 self.rewardedAd?.paidEventHandler = { adValue in
-                    let networkName = ad?.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                    let impressionId = ad?.responseInfo?.responseIdentifier ?? ""
+                    let networkName = ad?.responseInfo.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad?.responseInfo.responseIdentifier ?? ""
                     self.plugin?.notifyListeners(RewardAdPluginEvents.AdImpression.rawValue, data: [
                         "adUnitId": adUnitID,
                         "valueMicros": adValue.value.int64Value,

--- a/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
@@ -40,6 +40,20 @@ class AdRewardExecutor: NSObject, FullScreenContentDelegate {
                 }
 
                 self.rewardedAd?.fullScreenContentDelegate = self
+
+                self.rewardedAd?.paidEventHandler = { adValue in
+                    let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                    self.plugin?.notifyListeners(RewardAdPluginEvents.AdImpression.rawValue, data: [
+                        "adUnitId": adUnitID,
+                        "valueMicros": adValue.value.int64Value,
+                        "currencyCode": adValue.currencyCode,
+                        "precision": adValue.precision.rawValue,
+                        "networkName": networkName,
+                        "impressionId": impressionId
+                    ])
+                }
+
                 self.plugin?.notifyListeners(RewardAdPluginEvents.Loaded.rawValue, data: [
                     "adUnitId": adUnitID
                 ])

--- a/ios/Sources/AdMobPlugin/Rewarded/RewardAdPluginEvents.swift
+++ b/ios/Sources/AdMobPlugin/Rewarded/RewardAdPluginEvents.swift
@@ -5,4 +5,5 @@ public enum RewardAdPluginEvents: String {
     case FailedToShow = "onRewardedVideoAdFailedToShow"
     case Dismissed = "onRewardedVideoAdDismissed"
     case Rewarded = "onRewardedVideoAdReward"
+    case AdImpression = "onRewardedVideoAdImpression"
 }

--- a/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
@@ -42,8 +42,8 @@ class AdRewardInterstitialExecutor: NSObject, FullScreenContentDelegate {
                 self.rewardedInterstitialAd?.fullScreenContentDelegate = self
 
                 self.rewardedInterstitialAd?.paidEventHandler = { adValue in
-                    let networkName = ad?.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                    let impressionId = ad?.responseInfo?.responseIdentifier ?? ""
+                    let networkName = ad?.responseInfo.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad?.responseInfo.responseIdentifier ?? ""
                     self.plugin?.notifyListeners(RewardInterstitialAdPluginEvents.AdImpression.rawValue, data: [
                         "adUnitId": adUnitID,
                         "valueMicros": adValue.value.int64Value,

--- a/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
@@ -40,6 +40,20 @@ class AdRewardInterstitialExecutor: NSObject, FullScreenContentDelegate {
                 }
 
                 self.rewardedInterstitialAd?.fullScreenContentDelegate = self
+
+                self.rewardedInterstitialAd?.paidEventHandler = { adValue in
+                    let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                    self.plugin?.notifyListeners(RewardInterstitialAdPluginEvents.AdImpression.rawValue, data: [
+                        "adUnitId": adUnitID,
+                        "valueMicros": adValue.value.int64Value,
+                        "currencyCode": adValue.currencyCode,
+                        "precision": adValue.precision.rawValue,
+                        "networkName": networkName,
+                        "impressionId": impressionId
+                    ])
+                }
+
                 self.plugin?.notifyListeners(RewardInterstitialAdPluginEvents.Loaded.rawValue, data: [
                     "adUnitId": adUnitID
                 ])

--- a/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
@@ -42,8 +42,8 @@ class AdRewardInterstitialExecutor: NSObject, FullScreenContentDelegate {
                 self.rewardedInterstitialAd?.fullScreenContentDelegate = self
 
                 self.rewardedInterstitialAd?.paidEventHandler = { adValue in
-                    let networkName = ad.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
-                    let impressionId = ad.responseInfo?.responseIdentifier ?? ""
+                    let networkName = ad?.responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? ""
+                    let impressionId = ad?.responseInfo?.responseIdentifier ?? ""
                     self.plugin?.notifyListeners(RewardInterstitialAdPluginEvents.AdImpression.rawValue, data: [
                         "adUnitId": adUnitID,
                         "valueMicros": adValue.value.int64Value,

--- a/ios/Sources/AdMobPlugin/RewardedInterstitial/RewardInterstitialAdPluginEvents.swift
+++ b/ios/Sources/AdMobPlugin/RewardedInterstitial/RewardInterstitialAdPluginEvents.swift
@@ -5,4 +5,5 @@ public enum RewardInterstitialAdPluginEvents: String {
     case FailedToShow = "onRewardedInterstitialAdFailedToShow"
     case Dismissed = "onRewardedInterstitialAdDismissed"
     case Rewarded = "onRewardedInterstitialAdReward"
+    case AdImpression = "onRewardedInterstitialAdImpression"
 }

--- a/src/app-open/app-open-ad-plugin-events.enum.ts
+++ b/src/app-open/app-open-ad-plugin-events.enum.ts
@@ -4,4 +4,5 @@ export enum AppOpenAdPluginEvents {
   Opened = 'appOpenAdOpened',
   Closed = 'appOpenAdClosed',
   FailedToShow = 'appOpenAdFailedToShow',
+  AdImpression = 'appOpenAdImpression',
 }

--- a/src/app-open/app-open-definitions.interface.ts
+++ b/src/app-open/app-open-definitions.interface.ts
@@ -1,7 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented } from '../private/validate-all-events-implemented.type';
-import type { AdMobError } from '../shared';
+import type { AdMobError, AdMobRevenueData } from '../shared';
 
 import type { AppOpenAdOptions } from './app-open-ad-options.interface';
 import type { AppOpenAdPluginEvents } from './app-open-ad-plugin-events.enum';
@@ -41,5 +41,10 @@ export interface AppOpenAdPlugin {
   addListener(
     eventName: AppOpenAdPluginEvents.FailedToShow,
     listenerFunc: (error: AdMobError) => void,
+  ): Promise<PluginListenerHandle>;
+
+  addListener(
+    eventName: AppOpenAdPluginEvents.AdImpression,
+    listenerFunc: (data: AdMobRevenueData) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/src/banner/banner-ad-plugin-events.enum.ts
+++ b/src/banner/banner-ad-plugin-events.enum.ts
@@ -18,4 +18,5 @@ export enum BannerAdPluginEvents {
    * Similarly, this method should be called when an impression is recorded for the ad by the mediated SDK.
    */
   AdImpression = "bannerAdImpression",
+  AdPaid = "bannerAdPaid",
 }

--- a/src/banner/banner-definitions.interface.ts
+++ b/src/banner/banner-definitions.interface.ts
@@ -1,7 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented } from '../private/validate-all-events-implemented.type';
-import type { AdMobError } from '../shared';
+import type { AdMobError, AdMobRevenueData } from '../shared';
 
 import type { BannerAdOptions } from './banner-ad-options.interface';
 import type { BannerAdPluginEvents } from './banner-ad-plugin-events.enum';
@@ -122,5 +122,10 @@ export interface BannerDefinitions {
   addListener(
     eventName: BannerAdPluginEvents.AdImpression,
     listenerFunc: () => void,
+  ): Promise<PluginListenerHandle>;
+
+  addListener(
+    eventName: BannerAdPluginEvents.AdPaid,
+    listenerFunc: (data: AdMobRevenueData) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/src/interstitial/interstitial-ad-plugin-events.enum.ts
+++ b/src/interstitial/interstitial-ad-plugin-events.enum.ts
@@ -20,4 +20,8 @@ export enum InterstitialAdPluginEvents {
    * Emits when the Interstitial ad is not visible to the user anymore.
    */
   Dismissed= 'interstitialAdDismissed',
+  /**
+   * Emits when an impression-level ad revenue event is recorded
+   */
+  AdImpression = 'interstitialAdImpression',
 }

--- a/src/interstitial/interstitial-definitions.interface.ts
+++ b/src/interstitial/interstitial-definitions.interface.ts
@@ -1,7 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented } from '../private/validate-all-events-implemented.type';
-import type { AdLoadInfo, AdMobError, AdOptions } from '../shared';
+import type { AdLoadInfo, AdMobError, AdMobRevenueData, AdOptions } from '../shared';
 
 import type { InterstitialAdPluginEvents } from './interstitial-ad-plugin-events.enum';
 
@@ -53,5 +53,10 @@ export interface InterstitialDefinitions {
   addListener(
     eventName: InterstitialAdPluginEvents.Showed,
     listenerFunc: () => void,
+  ): Promise<PluginListenerHandle>;
+
+  addListener(
+    eventName: InterstitialAdPluginEvents.AdImpression,
+    listenerFunc: (data: AdMobRevenueData) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/src/reward-interstitial/reward-interstitial-ad-plugin-events.enum.ts
+++ b/src/reward-interstitial/reward-interstitial-ad-plugin-events.enum.ts
@@ -30,4 +30,8 @@ export enum RewardInterstitialAdPluginEvents {
    * Emits when user get rewarded from AdReward
    */
   Rewarded = 'onRewardedInterstitialAdReward',
+  /**
+   * Emits when an impression-level ad revenue event is recorded
+   */
+  AdImpression = 'onRewardedInterstitialAdImpression',
 }

--- a/src/reward-interstitial/reward-interstitial-definitions.interface.ts
+++ b/src/reward-interstitial/reward-interstitial-definitions.interface.ts
@@ -1,7 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented } from '../private/validate-all-events-implemented.type';
-import type { AdLoadInfo, AdMobError } from '../shared';
+import type { AdLoadInfo, AdMobError, AdMobRevenueData } from '../shared';
 
 import type { RewardInterstitialAdOptions } from './reward-interstitial-ad-options.interface';
 import type { RewardInterstitialAdPluginEvents } from './reward-interstitial-ad-plugin-events.enum';
@@ -62,5 +62,10 @@ export interface RewardInterstitialDefinitions {
   addListener(
     eventName: RewardInterstitialAdPluginEvents.Showed,
     listenerFunc: () => void,
+  ): Promise<PluginListenerHandle>;
+
+  addListener(
+    eventName: RewardInterstitialAdPluginEvents.AdImpression,
+    listenerFunc: (data: AdMobRevenueData) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/src/reward/reward-ad-plugin-events.enum.ts
+++ b/src/reward/reward-ad-plugin-events.enum.ts
@@ -30,4 +30,8 @@ export enum RewardAdPluginEvents {
    * Emits when user get rewarded from AdReward
    */
   Rewarded= 'onRewardedVideoAdReward',
+  /**
+   * Emits when an impression-level ad revenue event is recorded
+   */
+  AdImpression = 'onRewardedVideoAdImpression',
 }

--- a/src/reward/reward-definitions.interface.ts
+++ b/src/reward/reward-definitions.interface.ts
@@ -1,7 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented } from '../private/validate-all-events-implemented.type';
-import type { AdLoadInfo, AdMobError } from '../shared';
+import type { AdLoadInfo, AdMobError, AdMobRevenueData } from '../shared';
 
 import type { RewardAdOptions } from './reward-ad-options.interface';
 import type { RewardAdPluginEvents } from './reward-ad-plugin-events.enum';
@@ -59,5 +59,10 @@ export interface RewardDefinitions {
   addListener(
     eventName: RewardAdPluginEvents.Showed,
     listenerFunc: () => void,
+  ): Promise<PluginListenerHandle>;
+
+  addListener(
+    eventName: RewardAdPluginEvents.AdImpression,
+    listenerFunc: (data: AdMobRevenueData) => void,
   ): Promise<PluginListenerHandle>;
 }

--- a/src/shared/ad-mob-revenue-data.interface.ts
+++ b/src/shared/ad-mob-revenue-data.interface.ts
@@ -1,0 +1,15 @@
+export enum AdValuePrecision {
+  Unknown = 0,
+  Estimated = 1,
+  PublisherProvided = 2,
+  Precise = 3,
+}
+
+export interface AdMobRevenueData {
+  adUnitId: string;
+  valueMicros: number;
+  currencyCode: string;
+  precision: AdValuePrecision;
+  networkName: string;
+  impressionId: string;
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './ad-load-info.interface';
 export * from './ad-options.interface';
 export * from './admob-error.interface';
+export * from './ad-mob-revenue-data.interface';


### PR DESCRIPTION
I want to use the experimental [ad revenue tracking feature in RevenueCat](https://www.revenuecat.com/docs/getting-started/ad-monetization/manual-integration).

But it requires impression-level ad revenue data, which is currently not accessible, as mentioned in #414.

This PR includes changes to make that data available.