### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@capacitor-community/admob",
+  "private": false,
   "version": "8.0.0",
   "description": "A native plugin for AdMob",
   "main": "dist/plugin.cjs.js",


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.