### PR TITLE
fix: fall back to remaining prepared ad

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPlugin.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPlugin.kt
@@ -89,13 +89,17 @@ class AppOpenAdPlugin {
                 },
                 onClosed = {
                     preparedManagers.remove(adId)
-                    if (lastPreparedAdId == adId) lastPreparedAdId = preparedManagers.keys.lastOrNull()
+                    if (lastPreparedAdId == adId) {
+                        lastPreparedAdId = preparedManagers.entries.lastOrNull { it.value.isAdLoaded }?.key
+                    }
                     notifier.notify(AppOpenAdPluginEvents.Closed, JSObject())
                     call.resolve()
                 },
                 onFailedToShow = { adError ->
                     preparedManagers.remove(adId)
-                    if (lastPreparedAdId == adId) lastPreparedAdId = preparedManagers.keys.lastOrNull()
+                    if (lastPreparedAdId == adId) {
+                        lastPreparedAdId = preparedManagers.entries.lastOrNull { it.value.isAdLoaded }?.key
+                    }
                     val errorMessage = adError?.message ?: "Failed to show App Open Ad"
                     val errorCode = adError?.code ?: -1
                     notifier.notify(AppOpenAdPluginEvents.FailedToShow, AdMobPluginError(errorCode, errorMessage))

--- a/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPlugin.kt
+++ b/android/src/main/java/com/getcapacitor/community/admob/appopen/AppOpenAdPlugin.kt
@@ -89,13 +89,13 @@ class AppOpenAdPlugin {
                 },
                 onClosed = {
                     preparedManagers.remove(adId)
-                    if (lastPreparedAdId == adId) lastPreparedAdId = null
+                    if (lastPreparedAdId == adId) lastPreparedAdId = preparedManagers.keys.lastOrNull()
                     notifier.notify(AppOpenAdPluginEvents.Closed, JSObject())
                     call.resolve()
                 },
                 onFailedToShow = { adError ->
                     preparedManagers.remove(adId)
-                    if (lastPreparedAdId == adId) lastPreparedAdId = null
+                    if (lastPreparedAdId == adId) lastPreparedAdId = preparedManagers.keys.lastOrNull()
                     val errorMessage = adError?.message ?: "Failed to show App Open Ad"
                     val errorCode = adError?.code ?: -1
                     notifier.notify(AppOpenAdPluginEvents.FailedToShow, AdMobPluginError(errorCode, errorMessage))

--- a/android/src/main/java/com/getcapacitor/community/admob/interstitial/AdInterstitialExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/interstitial/AdInterstitialExecutor.java
@@ -78,7 +78,10 @@ public class AdInterstitialExecutor extends Executor {
                     adToShow.setFullScreenContentCallback(
                         new FullscreenPluginCallback(InterstitialAdPluginPluginEvent.INSTANCE, notifyListenersFunction, () -> {
                             preparedAds.remove(adId);
-                            if (adId != null && adId.equals(lastPreparedAdId)) lastPreparedAdId = null;
+                            if (adId != null && adId.equals(lastPreparedAdId)) {
+                                lastPreparedAdId = null;
+                                for (String remainingAdId : preparedAds.keySet()) lastPreparedAdId = remainingAdId;
+                            }
                         })
                     );
                     adToShow.show(activitySupplier.get());

--- a/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewarded/AdRewardExecutor.java
@@ -75,7 +75,10 @@ public class AdRewardExecutor extends Executor {
                     ad.setFullScreenContentCallback(
                         new FullscreenPluginCallback(RewardAdPluginEvents.INSTANCE, notifyListenersFunction, () -> {
                             preparedAds.remove(adId);
-                            if (adId != null && adId.equals(lastPreparedAdId)) lastPreparedAdId = null;
+                            if (adId != null && adId.equals(lastPreparedAdId)) {
+                                lastPreparedAdId = null;
+                                for (String remainingAdId : preparedAds.keySet()) lastPreparedAdId = remainingAdId;
+                            }
                         })
                     );
                     ad.show(

--- a/android/src/main/java/com/getcapacitor/community/admob/rewardedinterstitial/AdRewardInterstitialExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/rewardedinterstitial/AdRewardInterstitialExecutor.java
@@ -79,7 +79,10 @@ public class AdRewardInterstitialExecutor extends Executor {
                     ad.setFullScreenContentCallback(
                         new FullscreenPluginCallback(RewardInterstitialAdPluginEvents.INSTANCE, notifyListenersFunction, () -> {
                             preparedAds.remove(adId);
-                            if (adId != null && adId.equals(lastPreparedAdId)) lastPreparedAdId = null;
+                            if (adId != null && adId.equals(lastPreparedAdId)) {
+                                lastPreparedAdId = null;
+                                for (String remainingAdId : preparedAds.keySet()) lastPreparedAdId = remainingAdId;
+                            }
                         })
                     );
                     ad.show(

--- a/android/src/test/java/com/getcapacitor/community/admob/interstitial/AdInterstitialExecutorTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/interstitial/AdInterstitialExecutorTest.java
@@ -300,7 +300,12 @@ class AdInterstitialExecutorTest {
             verify(adTwo).setFullScreenContentCallback(callback.capture());
             callback.getValue().onAdDismissedFullScreenContent();
 
-            assertEquals("ad-unit-1", AdInterstitialExecutor.lastPreparedAdId);
+            reset(mockedActivity);
+            sut.showInterstitial(pluginCallMock, notifierMock);
+            verify(mockedActivity).runOnUiThread(runnableArgumentCaptor.capture());
+            runnableArgumentCaptor.getValue().run();
+
+            verify(adOne).show(any());
         }
 
         @Test

--- a/android/src/test/java/com/getcapacitor/community/admob/interstitial/AdInterstitialExecutorTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/interstitial/AdInterstitialExecutorTest.java
@@ -21,6 +21,7 @@ import com.getcapacitor.community.admob.helpers.AdViewIdHelper;
 import com.getcapacitor.community.admob.helpers.RequestHelper;
 import com.getcapacitor.community.admob.models.AdOptions;
 import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.interstitial.InterstitialAd;
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
 import com.google.android.gms.common.util.BiConsumer;
@@ -280,6 +281,26 @@ class AdInterstitialExecutorTest {
 
             verify(adTwo).show(any());
             verify(adOne, times(0)).show(any());
+        }
+
+        @Test
+        @DisplayName("Should fall back to the remaining prepared ad after dismissal")
+        void shouldFallBackToRemainingAdAfterDismissal() {
+            InterstitialAd adOne = mock(InterstitialAd.class);
+            InterstitialAd adTwo = mock(InterstitialAd.class);
+            AdInterstitialExecutor.preparedAds.put("ad-unit-1", adOne);
+            AdInterstitialExecutor.preparedAds.put("ad-unit-2", adTwo);
+            AdInterstitialExecutor.lastPreparedAdId = "ad-unit-2";
+
+            sut.showInterstitial(pluginCallMock, notifierMock);
+            verify(mockedActivity).runOnUiThread(runnableArgumentCaptor.capture());
+            runnableArgumentCaptor.getValue().run();
+
+            ArgumentCaptor<FullScreenContentCallback> callback = ArgumentCaptor.forClass(FullScreenContentCallback.class);
+            verify(adTwo).setFullScreenContentCallback(callback.capture());
+            callback.getValue().onAdDismissedFullScreenContent();
+
+            assertEquals("ad-unit-1", AdInterstitialExecutor.lastPreparedAdId);
         }
 
         @Test

--- a/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPlugin.swift
+++ b/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPlugin.swift
@@ -65,12 +65,16 @@ import UIKit
                     notify(AppOpenAdPluginEvents.Opened.rawValue, [:])
                 }, onClosed: {
                     self.preparedManagers.removeValue(forKey: adId)
-                    if self.lastPreparedAdId == adId { self.lastPreparedAdId = nil }
+                    if self.lastPreparedAdId == adId {
+                        self.lastPreparedAdId = Array(self.preparedManagers.keys).last
+                    }
                     notify(AppOpenAdPluginEvents.Closed.rawValue, [:])
                     call.resolve()
                 }, onFailedToShow: { error in
                     self.preparedManagers.removeValue(forKey: adId)
-                    if self.lastPreparedAdId == adId { self.lastPreparedAdId = nil }
+                    if self.lastPreparedAdId == adId {
+                        self.lastPreparedAdId = Array(self.preparedManagers.keys).last
+                    }
                     let message = error?.localizedDescription ?? "Failed to show App Open Ad"
                     notify(AppOpenAdPluginEvents.FailedToShow.rawValue, [
                         "code": 0,

--- a/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPlugin.swift
+++ b/ios/Sources/AdMobPlugin/AppOpen/AppOpenAdPlugin.swift
@@ -66,14 +66,14 @@ import UIKit
                 }, onClosed: {
                     self.preparedManagers.removeValue(forKey: adId)
                     if self.lastPreparedAdId == adId {
-                        self.lastPreparedAdId = Array(self.preparedManagers.keys).last
+                        self.lastPreparedAdId = self.preparedManagers.first(where: { $0.value.isAdLoaded() })?.key
                     }
                     notify(AppOpenAdPluginEvents.Closed.rawValue, [:])
                     call.resolve()
                 }, onFailedToShow: { error in
                     self.preparedManagers.removeValue(forKey: adId)
                     if self.lastPreparedAdId == adId {
-                        self.lastPreparedAdId = Array(self.preparedManagers.keys).last
+                        self.lastPreparedAdId = self.preparedManagers.first(where: { $0.value.isAdLoaded() })?.key
                     }
                     let message = error?.localizedDescription ?? "Failed to show App Open Ad"
                     notify(AppOpenAdPluginEvents.FailedToShow.rawValue, [

--- a/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Interstitial/AdInterstitialExecutor.swift
@@ -95,7 +95,7 @@ class AdInterstitialExecutor: NSObject, FullScreenContentDelegate {
     private func removeCurrentlyShowingAd() {
         guard let adId = currentlyShowingAdId else { return }
         preparedAds.removeValue(forKey: adId)
-        if lastPreparedAdId == adId { lastPreparedAdId = nil }
+        if lastPreparedAdId == adId { lastPreparedAdId = Array(preparedAds.keys).last }
         currentlyShowingAdId = nil
     }
 }

--- a/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
+++ b/ios/Sources/AdMobPlugin/Rewarded/AdRewardExecutor.swift
@@ -119,7 +119,7 @@ class AdRewardExecutor: NSObject, FullScreenContentDelegate {
     private func removeCurrentlyShowingAd() {
         guard let adId = currentlyShowingAdId else { return }
         preparedAds.removeValue(forKey: adId)
-        if lastPreparedAdId == adId { lastPreparedAdId = nil }
+        if lastPreparedAdId == adId { lastPreparedAdId = Array(preparedAds.keys).last }
         currentlyShowingAdId = nil
     }
 }

--- a/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
+++ b/ios/Sources/AdMobPlugin/RewardedInterstitial/AdRewardInterstitialExecutor.swift
@@ -119,7 +119,7 @@ class AdRewardInterstitialExecutor: NSObject, FullScreenContentDelegate {
     private func removeCurrentlyShowingAd() {
         guard let adId = currentlyShowingAdId else { return }
         preparedAds.removeValue(forKey: adId)
-        if lastPreparedAdId == adId { lastPreparedAdId = nil }
+        if lastPreparedAdId == adId { lastPreparedAdId = Array(preparedAds.keys).last }
         currentlyShowingAdId = nil
     }
 }


### PR DESCRIPTION
## What changed

- Keep a remaining prepared ad as the default after the latest ad is dismissed or fails to show.
- Apply the same minimal fallback to interstitial, rewarded, rewarded interstitial, and app open ads on Android and iOS.
- Add an Android regression test for the dismissal path.

## Why

When two ad units were prepared, consuming the most recently prepared ad cleared `lastPreparedAdId` even though another prepared ad remained. A subsequent `show*()` call without an explicit `adId` then failed.

## Impact

Existing explicit `adId` behavior is unchanged. Calls without `adId` can continue with a remaining prepared ad.

## Validation

- `npm run build`
- `npm run eslint`
- `npm run prettier -- --check`
- Android `./gradlew test` with JDK 21
- iOS `xcodebuild` for a generic iOS destination
