### PR TITLE
fix: type app open load info

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ Report application volume to AdMob SDK
 ### loadAppOpen(...)
 
 ```typescript
-loadAppOpen(options: AppOpenAdOptions) => Promise<void>
+loadAppOpen(options: AppOpenAdOptions) => Promise<AdLoadInfo>
 ```
 
 Load an App Open ad
@@ -542,6 +542,8 @@ Load an App Open ad
 | Param         | Type                                                          |
 | ------------- | ------------------------------------------------------------- |
 | **`options`** | <code><a href="#appopenadoptions">AppOpenAdOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#adloadinfo">AdLoadInfo</a>&gt;</code>
 
 --------------------
 
@@ -577,13 +579,13 @@ Check if the App Open ad is loaded
 ### addListener(AppOpenAdPluginEvents.Loaded, ...)
 
 ```typescript
-addListener(eventName: AppOpenAdPluginEvents.Loaded, listenerFunc: () => void) => Promise<PluginListenerHandle>
+addListener(eventName: AppOpenAdPluginEvents.Loaded, listenerFunc: (info: AdLoadInfo) => void) => Promise<PluginListenerHandle>
 ```
 
 | Param              | Type                                                                           |
 | ------------------ | ------------------------------------------------------------------------------ |
 | **`eventName`**    | <code><a href="#appopenadpluginevents">AppOpenAdPluginEvents.Loaded</a></code> |
-| **`listenerFunc`** | <code>() =&gt; void</code>                                                     |
+| **`listenerFunc`** | <code>(info: <a href="#adloadinfo">AdLoadInfo</a>) =&gt; void</code>           |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 

--- a/src/app-open/app-open-definitions.interface.ts
+++ b/src/app-open/app-open-definitions.interface.ts
@@ -1,7 +1,7 @@
 import type { PluginListenerHandle } from '@capacitor/core';
 
 import type { ValidateAllEventsEnumAreImplemented } from '../private/validate-all-events-implemented.type';
-import type { AdMobError, AdMobRevenueData, AdShowOptions } from '../shared';
+import type { AdLoadInfo, AdMobError, AdMobRevenueData, AdShowOptions } from '../shared';
 
 import type { AppOpenAdOptions } from './app-open-ad-options.interface';
 import type { AppOpenAdPluginEvents } from './app-open-ad-plugin-events.enum';
@@ -15,7 +15,7 @@ export interface AppOpenAdPlugin {
   /**
    * Load an App Open ad
    */
-  loadAppOpen(options: AppOpenAdOptions): Promise<void>;
+  loadAppOpen(options: AppOpenAdOptions): Promise<AdLoadInfo>;
 
   /**
    * Shows the App Open ad if loaded
@@ -29,7 +29,10 @@ export interface AppOpenAdPlugin {
    */
   isAppOpenLoaded(options?: AdShowOptions): Promise<{ value: boolean }>;
 
-  addListener(eventName: AppOpenAdPluginEvents.Loaded, listenerFunc: () => void): Promise<PluginListenerHandle>;
+  addListener(
+    eventName: AppOpenAdPluginEvents.Loaded,
+    listenerFunc: (info: AdLoadInfo) => void,
+  ): Promise<PluginListenerHandle>;
 
   addListener(
     eventName: AppOpenAdPluginEvents.FailedToLoad,

--- a/src/web.ts
+++ b/src/web.ts
@@ -121,8 +121,11 @@ export class AdMobWeb extends WebPlugin implements AdMobPlugin {
     };
   }
 
-  async loadAppOpen(options: AppOpenAdOptions): Promise<void> {
+  async loadAppOpen(options: AppOpenAdOptions): Promise<AdLoadInfo> {
     console.log('loadAppOpen', options);
+    return {
+      adUnitId: options.adId,
+    };
   }
 
   async showAppOpen(options?: AdShowOptions): Promise<void> {


### PR DESCRIPTION
## What changed

- Type `loadAppOpen()` as returning `AdLoadInfo`.
- Type the app open loaded event payload as `AdLoadInfo`.
- Return the same shape from the web implementation.
- Update only the corresponding generated API documentation entries.

## Why

The Android and iOS implementations already resolve app open loads and emit loaded events with `{ adUnitId }`, but the public TypeScript definitions declared no value. This hid the ad unit identifier needed by callers preparing multiple ads.

## Impact

Runtime behavior on Android and iOS is unchanged. TypeScript callers can now consume the existing `adUnitId` payload safely.

## Validation

- `npm run build`
- `npm run eslint`
- `npm run prettier -- --check`
