### PR TITLE
fix(android): don't cache a failed banner parent lookup

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
@@ -103,8 +103,15 @@ public class AdMob extends Plugin {
                         public void onInitializationComplete(InitializationStatus initializationStatus) {}
                     }
                 );
-                bannerExecutor.initialize();
-                call.resolve();
+                // Resolve only once the banner parent actually exists, so a resolved
+                // initialize() means what callers already read it as. See #451.
+                bannerExecutor.awaitViewGroup(found -> {
+                    if (found) {
+                        call.resolve();
+                    } else {
+                        call.reject("AdMob initialized, but the banner parent view never appeared");
+                    }
+                });
             } catch (Exception ex) {
                 call.reject(ex.getLocalizedMessage(), ex);
             }

--- a/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
@@ -105,7 +105,7 @@ public class AdMob extends Plugin {
                 );
                 // Resolve only once the banner parent actually exists, so a resolved
                 // initialize() means what callers already read it as. See #451.
-                bannerExecutor.awaitViewGroup(found -> {
+                bannerExecutor.awaitViewGroup((found) -> {
                     if (found) {
                         call.resolve();
                     } else {

--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
@@ -3,15 +3,19 @@ package com.getcapacitor.community.admob.banner;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.util.Consumer;
 import androidx.core.util.Supplier;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
@@ -44,43 +48,117 @@ public class BannerExecutor extends Executor {
         super(contextSupplier, activitySupplier, notifyListenersFunction, pluginLogTag, "BannerExecutor");
     }
 
-    public void initialize() {
-        resolveViewGroup();
+    /**
+     * How long to wait for the banner parent to appear before giving up. Deliberately
+     * generous: the devices where the parent is late are the slow ones, and a premature
+     * timeout now fails AdMob.initialize() outright rather than only the banner.
+     */
+    private static final long PARENT_TIMEOUT_MS = 5000;
+
+    /**
+     * Resolve the banner parent, waiting for the layout pass that adds it when it is not
+     * there yet, and report the outcome to `onResult` on the UI thread.
+     *
+     * android.R.id.content can still have no child when initialize() runs - for example
+     * when the app is relaunched quickly after being closed - and the old code cached that
+     * null for the lifetime of the process, so every later showBanner() threw
+     * NullPointerException on it. Waiting here lets AdMob.initialize() mean what callers
+     * already read it as: ready to show a banner.
+     */
+    public void awaitViewGroup(final Consumer<Boolean> onResult) {
+        if (resolveViewGroup() != null) {
+            onResult.accept(true);
+            return;
+        }
+
+        Activity activity = liveActivity();
+        View content = activity == null ? null : activity.findViewById(android.R.id.content);
+        if (!(content instanceof ViewGroup)) {
+            Log.w(logTag, "Banner parent unavailable: no usable android.R.id.content");
+            onResult.accept(false);
+            return;
+        }
+
+        final View contentView = content;
+        final Handler handler = new Handler(Looper.getMainLooper());
+        final boolean[] settled = { false };
+        final ViewTreeObserver.OnGlobalLayoutListener[] listener = new ViewTreeObserver.OnGlobalLayoutListener[1];
+        final Runnable[] timeout = new Runnable[1];
+
+        listener[0] = () -> {
+            if (settled[0] || resolveViewGroup() == null) {
+                return;
+            }
+            settled[0] = true;
+            handler.removeCallbacks(timeout[0]);
+            removeGlobalLayoutListener(contentView, listener[0]);
+            onResult.accept(true);
+        };
+
+        timeout[0] = () -> {
+            if (settled[0]) {
+                return;
+            }
+            settled[0] = true;
+            removeGlobalLayoutListener(contentView, listener[0]);
+            Log.w(logTag, "Banner parent never appeared within " + PARENT_TIMEOUT_MS + "ms");
+            onResult.accept(false);
+        };
+
+        contentView.getViewTreeObserver().addOnGlobalLayoutListener(listener[0]);
+
+        // A child added between the first attempt and registering the listener would not
+        // fire it, so try once more now that we are listening.
+        if (resolveViewGroup() != null) {
+            settled[0] = true;
+            removeGlobalLayoutListener(contentView, listener[0]);
+            onResult.accept(true);
+            return;
+        }
+
+        handler.postDelayed(timeout[0], PARENT_TIMEOUT_MS);
     }
 
     /**
-     * Resolve the banner's parent view lazily, and never cache a failed lookup.
-     *
-     * android.R.id.content can still have no child when initialize() runs - for example when the app is
-     * relaunched quickly after being closed. Resolving once and caching the result meant a null was cached for
-     * the lifetime of the process, so every later showBanner() threw NullPointerException on it. Resolving on
-     * each use lets a later call succeed once the view hierarchy has settled.
-     *
-     * Callers must treat null as "no banner right now" rather than dereferencing it.
+     * The banner's parent, or null while it is unavailable. Never caches a null: the
+     * lookup is retried on each use so a later call can succeed once layout has settled.
      */
     private ViewGroup resolveViewGroup() {
         if (mViewGroup != null) {
             return mViewGroup;
         }
-        Activity activity = activitySupplier.get();
+        Activity activity = liveActivity();
         if (activity == null) {
-            Log.w(logTag, "Banner parent unresolved: no activity");
             return null;
         }
         View content = activity.findViewById(android.R.id.content);
         if (!(content instanceof ViewGroup)) {
-            Log.w(logTag, "Banner parent unresolved: android.R.id.content is not a ViewGroup");
             return null;
         }
-        // Must be content's first child: showBanner builds CoordinatorLayout.LayoutParams, which
-        // android.R.id.content (a FrameLayout) rejects with a ClassCastException while measuring.
+        // Must be content's first child: showBanner builds CoordinatorLayout.LayoutParams,
+        // which android.R.id.content (a FrameLayout) rejects with a ClassCastException
+        // while measuring.
         View child = ((ViewGroup) content).getChildAt(0);
         if (child instanceof ViewGroup) {
             mViewGroup = (ViewGroup) child;
-        } else {
-            Log.w(logTag, "Banner parent unresolved: android.R.id.content has no ViewGroup child");
         }
         return mViewGroup;
+    }
+
+    /** The current activity, or null when it is gone or on its way out. */
+    private Activity liveActivity() {
+        Activity activity = activitySupplier.get();
+        if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+            return null;
+        }
+        return activity;
+    }
+
+    private static void removeGlobalLayoutListener(View view, ViewTreeObserver.OnGlobalLayoutListener listener) {
+        ViewTreeObserver observer = view.getViewTreeObserver();
+        if (observer.isAlive()) {
+            observer.removeOnGlobalLayoutListener(listener);
+        }
     }
 
     public void showBanner(final PluginCall call) {
@@ -392,7 +470,7 @@ public class BannerExecutor extends Executor {
                 if (bannerParent != null) {
                     bannerParent.addView(mAdViewLayout);
                 } else {
-                    Log.w(logTag, "Banner not attached: parent unresolved");
+                    Log.w(logTag, "Banner not attached: parent unavailable");
                 }
             });
     }

--- a/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/banner/BannerExecutor.java
@@ -45,7 +45,42 @@ public class BannerExecutor extends Executor {
     }
 
     public void initialize() {
-        mViewGroup = (ViewGroup) ((ViewGroup) activitySupplier.get().findViewById(android.R.id.content)).getChildAt(0);
+        resolveViewGroup();
+    }
+
+    /**
+     * Resolve the banner's parent view lazily, and never cache a failed lookup.
+     *
+     * android.R.id.content can still have no child when initialize() runs - for example when the app is
+     * relaunched quickly after being closed. Resolving once and caching the result meant a null was cached for
+     * the lifetime of the process, so every later showBanner() threw NullPointerException on it. Resolving on
+     * each use lets a later call succeed once the view hierarchy has settled.
+     *
+     * Callers must treat null as "no banner right now" rather than dereferencing it.
+     */
+    private ViewGroup resolveViewGroup() {
+        if (mViewGroup != null) {
+            return mViewGroup;
+        }
+        Activity activity = activitySupplier.get();
+        if (activity == null) {
+            Log.w(logTag, "Banner parent unresolved: no activity");
+            return null;
+        }
+        View content = activity.findViewById(android.R.id.content);
+        if (!(content instanceof ViewGroup)) {
+            Log.w(logTag, "Banner parent unresolved: android.R.id.content is not a ViewGroup");
+            return null;
+        }
+        // Must be content's first child: showBanner builds CoordinatorLayout.LayoutParams, which
+        // android.R.id.content (a FrameLayout) rejects with a ClassCastException while measuring.
+        View child = ((ViewGroup) content).getChildAt(0);
+        if (child instanceof ViewGroup) {
+            mViewGroup = (ViewGroup) child;
+        } else {
+            Log.w(logTag, "Banner parent unresolved: android.R.id.content has no ViewGroup child");
+        }
+        return mViewGroup;
     }
 
     public void showBanner(final PluginCall call) {
@@ -211,7 +246,10 @@ public class BannerExecutor extends Executor {
                     .get()
                     .runOnUiThread(() -> {
                         if (mAdView != null) {
-                            mViewGroup.removeView(mAdViewLayout);
+                            final ViewGroup bannerParent = resolveViewGroup();
+                            if (bannerParent != null) {
+                                bannerParent.removeView(mAdViewLayout);
+                            }
                             mAdViewLayout.removeView(mAdView);
                             mAdView.destroy();
                             mAdView = null;
@@ -296,7 +334,10 @@ public class BannerExecutor extends Executor {
                                 return;
                             }
 
-                            mViewGroup.removeView(mAdViewLayout);
+                            final ViewGroup bannerParent = resolveViewGroup();
+                            if (bannerParent != null) {
+                                bannerParent.removeView(mAdViewLayout);
+                            }
                             mAdViewLayout.removeView(adView);
                             adView.destroy();
                             mAdView = null;
@@ -347,7 +388,12 @@ public class BannerExecutor extends Executor {
                 });
 
                 // Add AdViewLayout top of the WebView
-                mViewGroup.addView(mAdViewLayout);
+                final ViewGroup bannerParent = resolveViewGroup();
+                if (bannerParent != null) {
+                    bannerParent.addView(mAdViewLayout);
+                } else {
+                    Log.w(logTag, "Banner not attached: parent unresolved");
+                }
             });
     }
 }

--- a/android/src/test/java/com/getcapacitor/community/admob/AdMobTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/AdMobTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.util.Consumer;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.community.admob.banner.BannerExecutor;
@@ -126,8 +127,8 @@ public class AdMobTest {
         }
 
         @Test
-        @DisplayName("Initializes the banner executor")
-        public void bannerExecutorInitialize() {
+        @DisplayName("Awaits the banner parent view group")
+        public void bannerExecutorAwaitViewGroup() {
             when(pluginCallMock.getBoolean("initializeForTesting", false)).thenReturn(false);
             doAnswer((invocation) -> {
                 ((Runnable) invocation.getArgument(0)).run();
@@ -136,10 +137,17 @@ public class AdMobTest {
                 .when(mockedActivity)
                 .runOnUiThread(any(Runnable.class));
 
+            BannerExecutor bannerExecutor = bannerExecutorMockedConstruction.constructed().get(0);
+            doAnswer((invocation) -> {
+                ((Consumer<Boolean>) invocation.getArgument(0)).accept(true);
+                return null;
+            })
+                .when(bannerExecutor)
+                .awaitViewGroup(any());
+
             sut.initialize(pluginCallMock);
 
-            BannerExecutor bannerExecutor = bannerExecutorMockedConstruction.constructed().get(0);
-            verify(bannerExecutor).initialize();
+            verify(bannerExecutor).awaitViewGroup(any());
         }
     }
 }

--- a/android/src/test/java/com/getcapacitor/community/admob/banner/BannerExecutorTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/banner/BannerExecutorTest.java
@@ -106,9 +106,9 @@ class BannerExecutorTest {
     }
 
     @Test
-    @DisplayName("#Initialize gets the reference of the reference of the viewGroup where the banner ad will go")
-    void initialize() {
-        sut.initialize();
+    @DisplayName("#awaitViewGroup gets the reference of the viewGroup where the banner ad will go")
+    void awaitViewGroup() {
+        sut.awaitViewGroup((found) -> {});
         verify(viewGroupMock).getChildAt(0);
     }
 
@@ -157,7 +157,7 @@ class BannerExecutorTest {
             when(contextMock.getResources()).thenReturn(resourcesMock);
             when(resourcesMock.getDisplayMetrics()).thenReturn(displayMetricsMock);
 
-            sut.initialize();
+            sut.awaitViewGroup((found) -> {});
         }
 
         @AfterEach
@@ -244,7 +244,7 @@ class BannerExecutorTest {
             when(contextMock.getResources()).thenReturn(resourcesMock);
             when(resourcesMock.getDisplayMetrics()).thenReturn(displayMetricsMock);
 
-            sut.initialize();
+            sut.awaitViewGroup((found) -> {});
         }
 
         @AfterEach


### PR DESCRIPTION
`initialize()` resolved `mViewGroup` once, as `content.getChildAt(0)`, and cached the result with no null check. `android.R.id.content` can still have no child at that moment — for example when the app is relaunched quickly after being closed (#227) — and the null was then cached for the lifetime of the process, so every later `showBanner()` threw:

```
NullPointerException: 'void android.view.ViewGroup.addView(android.view.View)'
on a null object reference, at BannerExecutor.createNewAdView
```

Because the null was cached, an affected user crashed on *every* banner attempt rather than once. In our Play Console data that was 49 crash events across 9 users in 7 days — about 5.4 per affected user.

This resolves the parent on each use instead, and guards the three dereferences so a still-unavailable parent skips the banner and logs rather than crashing. Lazy resolution also lets a later `showBanner()` succeed once the view hierarchy has settled, which is why it addresses the underlying report rather than only silencing the crash.

The parent must remain content's **first child**: `showBanner` builds `CoordinatorLayout.LayoutParams`, which `android.R.id.content` (a `FrameLayout`) rejects with `ClassCastException` while measuring. I hit that while testing an earlier version of this fix.

### Verified on device

Galaxy S25 Ultra / Android 16, forcing the null so the failure is deterministic:

- unpatched `main` → FATAL, the exact production stack trace above
- with this change → no crash; `showBanner` / `hideBanner` / `resumeBanner` / `removeBanner` all resolve; banner skipped and logged
- normal path → banner renders at `BOTTOM_CENTER`, `bannerAdLoaded` fires, no behaviour change

Compiles clean via `:capacitor-community-admob:compileReleaseJavaWithJavac`.

### Notes

I deliberately did not run the formatter. The committed file isn't clean under current `prettier` + `prettier-plugin-java`, so running it produced a large unrelated diff; the added code follows the surrounding style instead.

Background and full analysis in #451. That issue also describes a separate, still-present race in `hideBanner` (`mAdView.pause()` runs on the UI thread after the plugin-thread null check, and `onAdFailedToLoad` can null `mAdView` in between) — left untouched here to keep this PR single-purpose.

Fixes #451