### PR TITLE
docs: embed API references in guides

### DIFF
--- a/docs/app-open.md
+++ b/docs/app-open.md
@@ -38,7 +38,13 @@ if (isLoaded) {
 }
 ```
 
-Request fields are defined on [`AppOpenAdOptions`](../README.md#appopenadoptions).
+<!-- !::loadAppOpen:: -->
+
+<!-- !::isAppOpenLoaded:: -->
+
+<!-- !::showAppOpen:: -->
+
+<!-- !::AppOpenAdOptions:: -->
 
 There is no `isTesting` flag; during development set `adId` to Google's [App Open demo ad unit](https://developers.google.com/admob/android/test-ads#demo_ad_units).
 

--- a/docs/banner.md
+++ b/docs/banner.md
@@ -43,6 +43,14 @@ const options: BannerAdOptions = {
 await AdMob.showBanner(options);
 ```
 
+<!-- !::showBanner:: -->
+
+<!-- !::BannerAdOptions:: -->
+
+<!-- !::BannerAdSize:: -->
+
+<!-- !::BannerAdPosition:: -->
+
 ## Keep content out from under the banner
 
 The banner is drawn on the native screen above the WebView. HTML layout does not move on its own. Inset your own root by `size.height` (logical pixels). Use padding or margin on the bottom for `BOTTOM_CENTER`, and on the top for `TOP_CENTER`.
@@ -66,13 +74,19 @@ await AdMob.addListener(BannerAdPluginEvents.SizeChanged, (size) => {
 
 When the height is `0` (hidden, removed, or failed), clear the inset. Apply the same idea to whatever element fills the WebView in your framework.
 
-Request fields are defined on [`BannerAdOptions`](../README.md#banneradoptions). See [Testing](./testing.md) for `isTesting`.
+See [Testing](./testing.md) for `isTesting`.
 
 ## Lifecycle
 
 - `hideBanner()` temporarily hides the current banner.
 - `resumeBanner()` shows a hidden banner again.
 - `removeBanner()` destroys it. Call `showBanner()` to create another one.
+
+<!-- !::hideBanner:: -->
+
+<!-- !::resumeBanner:: -->
+
+<!-- !::removeBanner:: -->
 
 Release listener handles when the owning screen is destroyed:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,8 +10,12 @@ import { AdMob } from '@capacitor-community/admob';
 await AdMob.initialize();
 ```
 
+<!-- !::initialize:: -->
+
+<!-- !::AdMobInitializationOptions:: -->
+
 During development, prefer Google [demo ad units](https://developers.google.com/admob/android/test-ads#demo_ad_units). To test production-like ads on a physical device, register that device as described in [Testing](./testing.md). Do not ship `initializeForTesting: true` in production.
 
-Initialization fields are defined on [`AdMobInitializationOptions`](../README.md#admobinitializationoptions). Per-ad options such as `isTesting`, `npa` (non-personalized ads), and `immersiveMode` (hide Android system bars on a full-screen ad) are set on each ad request, not on `initialize`. See the per-format guides.
+Per-ad options such as `isTesting`, `npa` (non-personalized ads), and `immersiveMode` (hide Android system bars on a full-screen ad) are set on each ad request, not on `initialize`. See the per-format guides.
 
 After initialization, request privacy consent before loading ads. See [Consent](./consent.md).

--- a/docs/consent.md
+++ b/docs/consent.md
@@ -26,6 +26,16 @@ if (consentInfo.canRequestAds) {
 }
 ```
 
+<!-- !::requestConsentInfo:: -->
+
+<!-- !::AdmobConsentRequestOptions:: -->
+
+<!-- !::AdmobConsentInfo:: -->
+
+<!-- !::AdmobConsentStatus:: -->
+
+<!-- !::showConsentForm:: -->
+
 Use `canRequestAds` as the decision point. A consent form may be unavailable or unnecessary depending on the user and the messages you configured.
 
 ## iOS tracking authorization
@@ -45,6 +55,12 @@ if (tracking.status === 'notDetermined') {
 
 `requestTrackingAuthorization()` does nothing on Android, web, and iOS versions before 14.
 
+<!-- !::trackingAuthorizationStatus:: -->
+
+<!-- !::TrackingAuthorizationStatusInterface:: -->
+
+<!-- !::requestTrackingAuthorization:: -->
+
 ## Privacy options
 
 If your privacy message requires an in-app entry point, expose a settings action that calls:
@@ -53,8 +69,12 @@ If your privacy message requires an in-app entry point, expose a settings action
 await AdMob.showPrivacyOptionsForm();
 ```
 
+<!-- !::showPrivacyOptionsForm:: -->
+
 ## Reset consent
 
 `resetConsentInfo()` is intended for testing. Do not use it to clear a production user's consent choice.
+
+<!-- !::resetConsentInfo:: -->
 
 For debug geography and test device IDs, see [Testing](./testing.md).

--- a/docs/events.md
+++ b/docs/events.md
@@ -18,6 +18,8 @@ const handle = await AdMob.addListener(BannerAdPluginEvents.Loaded, () => {
 await handle.remove();
 ```
 
+<!-- !::PluginListenerHandle:: -->
+
 ## Common lifecycle events
 
 | Event                     | Emitted when                                           |
@@ -33,11 +35,15 @@ await handle.remove();
 
 ## Errors
 
-`FailedToLoad` and `FailedToShow` listeners receive an [`AdMobError`](../README.md#admoberror).
+`FailedToLoad` and `FailedToShow` listeners receive an `AdMobError` payload.
+
+<!-- !::AdMobError:: -->
 
 ## Impression-level revenue
 
-Full-screen formats emit [`AdMobRevenueData`](../README.md#admobrevenuedata) on their `AdImpression` event. Banners emit the same payload on `AdPaid`. Banner `AdImpression` has no payload; it only signals that an impression was recorded.
+Full-screen formats emit `AdMobRevenueData` on their `AdImpression` event. Banners emit the same payload on `AdPaid`. Banner `AdImpression` has no payload; it only signals that an impression was recorded.
+
+<!-- !::AdMobRevenueData:: -->
 
 ## Per-format guides
 
@@ -46,4 +52,22 @@ Full-screen formats emit [`AdMobRevenueData`](../README.md#admobrevenuedata) on 
 - [Interstitial Ads](./interstitial.md)
 - [Rewarded Ads](./rewarded.md)
 
-Method and enum signatures are in the [API reference](../README.md#api).
+<!-- !::addListener.AppOpenAdPluginEvents:: -->
+
+<!-- !::AppOpenAdPluginEvents:: -->
+
+<!-- !::addListener.BannerAdPluginEvents:: -->
+
+<!-- !::BannerAdPluginEvents:: -->
+
+<!-- !::addListener.InterstitialAdPluginEvents:: -->
+
+<!-- !::InterstitialAdPluginEvents:: -->
+
+<!-- !::addListener.RewardAdPluginEvents:: -->
+
+<!-- !::RewardAdPluginEvents:: -->
+
+<!-- !::addListener.RewardInterstitialAdPluginEvents:: -->
+
+<!-- !::RewardInterstitialAdPluginEvents:: -->

--- a/docs/interstitial.md
+++ b/docs/interstitial.md
@@ -5,13 +5,7 @@ Interstitial ads are full-screen ads that cover the host app. Show them at a nat
 Use an interstitial when the user should not receive an in-app reward. Call this after [initialize](./configuration.md) and [consent](./consent.md). Prepare the ad ahead of time, register listeners first, and show it only when it is ready.
 
 ```ts
-import {
-  AdLoadInfo,
-  AdMob,
-  AdMobRevenueData,
-  AdOptions,
-  InterstitialAdPluginEvents,
-} from '@capacitor-community/admob';
+import { AdLoadInfo, AdMob, AdMobRevenueData, AdOptions, InterstitialAdPluginEvents } from '@capacitor-community/admob';
 
 await AdMob.addListener(InterstitialAdPluginEvents.Loaded, (info: AdLoadInfo) => {
   console.log('Interstitial loaded', info.adUnitId);
@@ -31,6 +25,12 @@ const { adUnitId } = await AdMob.prepareInterstitial(options);
 await AdMob.showInterstitial({ adId: adUnitId });
 ```
 
+<!-- !::prepareInterstitial:: -->
+
+<!-- !::showInterstitial:: -->
+
+<!-- !::AdOptions:: -->
+
 When no `adId` is passed to `showInterstitial()`, the most recently prepared ad is shown.
 
 ## Prepare more than one ad
@@ -42,6 +42,6 @@ await AdMob.prepareInterstitial({ adId: 'ca-app-pub-xxx/interstitial-2' });
 await AdMob.showInterstitial({ adId: 'ca-app-pub-xxx/interstitial-1' });
 ```
 
-Request fields are defined on [`AdOptions`](../README.md#adoptions). See [Testing](./testing.md) for `isTesting`.
+See [Testing](./testing.md) for `isTesting`.
 
 Load, show, dismissal, and failure events are listed on [Ad Events](./events.md).

--- a/docs/rewarded.md
+++ b/docs/rewarded.md
@@ -45,6 +45,14 @@ const rewardItem = await AdMob.showRewardVideoAd();
 console.log(rewardItem);
 ```
 
+<!-- !::prepareRewardVideoAd:: -->
+
+<!-- !::showRewardVideoAd:: -->
+
+<!-- !::RewardAdOptions:: -->
+
+<!-- !::AdMobRewardItem:: -->
+
 When no `adId` is passed to `showRewardVideoAd()`, the most recently prepared ad is shown.
 
 ### Prepare more than one ad
@@ -82,7 +90,15 @@ const rewardItem: AdMobRewardInterstitialItem = await AdMob.showRewardInterstiti
 console.log(rewardItem);
 ```
 
-Request fields are defined on [`RewardAdOptions`](../README.md#rewardadoptions) and [`RewardInterstitialAdOptions`](../README.md#rewardinterstitialadoptions). See [Testing](./testing.md) for `isTesting`.
+<!-- !::prepareRewardInterstitialAd:: -->
+
+<!-- !::showRewardInterstitialAd:: -->
+
+<!-- !::RewardInterstitialAdOptions:: -->
+
+<!-- !::AdMobRewardInterstitialItem:: -->
+
+See [Testing](./testing.md) for `isTesting`.
 
 ## Server-side verification
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,10 @@ await AdMob.initialize({
 });
 ```
 
+<!-- !::initialize:: -->
+
+<!-- !::AdMobInitializationOptions:: -->
+
 Find the device ID in the native logs after the first ad request:
 
 - Android: Logcat, typically on the `Ads` tag (`Use RequestConfiguration.Builder.setTestDeviceIds(...)`).
@@ -40,6 +44,12 @@ const consentInfo = await AdMob.requestConsentInfo({
   testDeviceIdentifiers: ['YOUR_TEST_DEVICE_ID'],
 });
 ```
+
+<!-- !::requestConsentInfo:: -->
+
+<!-- !::AdmobConsentRequestOptions:: -->
+
+<!-- !::AdmobConsentDebugGeography:: -->
 
 If you decline consent in the test form (Manage → Confirm Choices), ads may not load. That is expected in a test environment and does not predict production behavior after a user consents.
 


### PR DESCRIPTION
## Summary

- AdMob guidesの手書きAPI誘導をdocgen placeholderへ置き換える
- docs.rdlabo.devで公開版docs.jsonから正確なシグネチャと型情報を展開できるようにする
- イベントリスナーはページに適した全体・イベント群・個別イベントの粒度を使う

## Validation

- Prettier check
- git diff --check
- rdlabo-siteの公開版docs.jsonに対して全placeholderが解決することを確認

## Dependency

Dotted event placeholders require rdlabo-dev/website#20 to be merged before this documentation is consumed by docs.rdlabo.dev.