### PR TITLE
fix(android): initialize Mobile Ads off the UI thread

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
+++ b/android/src/main/java/com/getcapacitor/community/admob/AdMob.java
@@ -21,8 +21,6 @@ import com.getcapacitor.community.admob.rewarded.AdRewardExecutor;
 import com.getcapacitor.community.admob.rewardedinterstitial.AdRewardInterstitialExecutor;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
-import com.google.android.gms.ads.initialization.InitializationStatus;
-import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 import org.json.JSONException;
 
 @CapacitorPlugin(
@@ -93,35 +91,36 @@ public class AdMob extends Plugin {
     public void initialize(final PluginCall call) {
         this.setRequestConfiguration(call);
 
-        // Same as banner/interstitial: bridge thread is not the UI thread — MobileAds + view setup must run on main.
-        Runnable initOnMain = () -> {
+        // Capacitor's executor runs on the plugin thread, keeping SDK class loading
+        // and initialization off the UI thread. Only view setup belongs on main.
+        execute(() -> {
             try {
-                MobileAds.initialize(
-                    getContext(),
-                    new OnInitializationCompleteListener() {
-                        @Override
-                        public void onInitializationComplete(InitializationStatus initializationStatus) {}
-                    }
-                );
-                // Resolve only once the banner parent actually exists, so a resolved
-                // initialize() means what callers already read it as. See #451.
-                bannerExecutor.awaitViewGroup((found) -> {
-                    if (found) {
-                        call.resolve();
+                MobileAds.initialize(getContext(), (initializationStatus) -> {
+                    Runnable prepareBanner = () -> {
+                        try {
+                            // Preserve the banner readiness guarantee before resolving.
+                            bannerExecutor.awaitViewGroup((found) -> {
+                                if (found) {
+                                    call.resolve();
+                                } else {
+                                    call.reject("AdMob initialized, but the banner parent view never appeared");
+                                }
+                            });
+                        } catch (Exception ex) {
+                            call.reject(ex.getLocalizedMessage(), ex);
+                        }
+                    };
+                    Activity activity = getActivity();
+                    if (activity != null) {
+                        activity.runOnUiThread(prepareBanner);
                     } else {
-                        call.reject("AdMob initialized, but the banner parent view never appeared");
+                        new Handler(Looper.getMainLooper()).post(prepareBanner);
                     }
                 });
             } catch (Exception ex) {
                 call.reject(ex.getLocalizedMessage(), ex);
             }
-        };
-        Activity activity = getActivity();
-        if (activity != null) {
-            activity.runOnUiThread(initOnMain);
-        } else {
-            new Handler(Looper.getMainLooper()).post(initOnMain);
-        }
+        });
     }
 
     @PluginMethod

--- a/android/src/test/java/com/getcapacitor/community/admob/AdMobTest.java
+++ b/android/src/test/java/com/getcapacitor/community/admob/AdMobTest.java
@@ -3,6 +3,8 @@ package com.getcapacitor.community.admob;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,6 +18,9 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.community.admob.banner.BannerExecutor;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.RequestConfiguration;
+import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
+import java.util.ArrayDeque;
+import java.util.Queue;
 import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,12 +51,19 @@ public class AdMobTest {
     MockedConstruction<BannerExecutor> bannerExecutorMockedConstruction;
 
     AdMob sut;
+    Queue<Runnable> backgroundTasks;
 
     @BeforeEach
     public void beforeEach() {
         reset(pluginCallMock, mockedContext);
 
+        backgroundTasks = new ArrayDeque<>();
         sut = new AdMob() {
+            @Override
+            public void execute(Runnable runnable) {
+                backgroundTasks.add(runnable);
+            }
+
             @Override
             public Context getContext() {
                 return mockedContext;
@@ -147,7 +159,67 @@ public class AdMobTest {
 
             sut.initialize(pluginCallMock);
 
+            verify(bannerExecutor, never()).awaitViewGroup(any());
+            verify(pluginCallMock, never()).resolve();
+            mobileAdsMockedStatic.verify(() -> MobileAds.initialize(any(), any()), never());
+
+            backgroundTasks.remove().run();
+            ArgumentCaptor<OnInitializationCompleteListener> callback = ArgumentCaptor.forClass(OnInitializationCompleteListener.class);
+            mobileAdsMockedStatic.verify(() -> MobileAds.initialize(any(), callback.capture()));
+            verify(bannerExecutor, never()).awaitViewGroup(any());
+            verify(pluginCallMock, never()).resolve();
+
+            callback.getValue().onInitializationComplete(null);
+            verify(mockedActivity).runOnUiThread(any(Runnable.class));
             verify(bannerExecutor).awaitViewGroup(any());
+            verify(pluginCallMock).resolve();
+        }
+
+        @Test
+        public void sdkFailureRejectsWithoutPreparingBanner() {
+            RuntimeException failure = new RuntimeException("SDK initialization failed");
+            mobileAdsMockedStatic.when(() -> MobileAds.initialize(any(), any())).thenThrow(failure);
+            sut.initialize(pluginCallMock);
+            backgroundTasks.remove().run();
+            verify(pluginCallMock).reject(failure.getMessage(), failure);
+            verify(pluginCallMock, never()).resolve();
+            verify(mockedActivity, never()).runOnUiThread(any());
+        }
+
+        @Test
+        public void waitsForMainThreadAndRejectsMissingBannerParent() {
+            sut.initialize(pluginCallMock);
+            backgroundTasks.remove().run();
+            ArgumentCaptor<OnInitializationCompleteListener> callback = ArgumentCaptor.forClass(OnInitializationCompleteListener.class);
+            mobileAdsMockedStatic.verify(() -> MobileAds.initialize(any(), callback.capture()));
+            callback.getValue().onInitializationComplete(null);
+            ArgumentCaptor<Runnable> uiTask = ArgumentCaptor.forClass(Runnable.class);
+            verify(mockedActivity).runOnUiThread(uiTask.capture());
+            BannerExecutor banner = bannerExecutorMockedConstruction.constructed().get(0);
+            verify(banner, never()).awaitViewGroup(any());
+            uiTask.getValue().run();
+            ArgumentCaptor<Consumer<Boolean>> ready = ArgumentCaptor.forClass(Consumer.class);
+            verify(banner).awaitViewGroup(ready.capture());
+            verify(pluginCallMock, never()).resolve();
+            ready.getValue().accept(false);
+            verify(pluginCallMock).reject("AdMob initialized, but the banner parent view never appeared");
+        }
+
+        @Test
+        public void bannerSetupFailureRejects() {
+            BannerExecutor banner = bannerExecutorMockedConstruction.constructed().get(0);
+            RuntimeException failure = new RuntimeException("View setup failed");
+            doThrow(failure).when(banner).awaitViewGroup(any());
+            sut.initialize(pluginCallMock);
+            backgroundTasks.remove().run();
+            ArgumentCaptor<OnInitializationCompleteListener> callback = ArgumentCaptor.forClass(OnInitializationCompleteListener.class);
+            mobileAdsMockedStatic.verify(() -> MobileAds.initialize(any(), callback.capture()));
+            callback.getValue().onInitializationComplete(null);
+            ArgumentCaptor<Runnable> uiTask = ArgumentCaptor.forClass(Runnable.class);
+            verify(mockedActivity).runOnUiThread(uiTask.capture());
+            uiTask.getValue().run();
+            verify(pluginCallMock).reject(failure.getMessage(), failure);
+            verify(pluginCallMock, never()).resolve();
         }
     }
 }


### PR DESCRIPTION
Mobile Ads initialization currently runs on the Android UI thread. Production ANR traces from an app using plugin 8.1.0 and GMA 25.4.0 show the main thread inside `MobileAds.initialize()`, including DEX/class loading. This change moves that call to Capacitor's existing plugin executor, then dispatches banner setup to the UI thread from the SDK completion callback.

The initialization promise now waits for SDK completion as well as the existing banner parent readiness check. SDK exceptions, banner setup exceptions, and missing banner parents reject the call. This preserves main's `awaitViewGroup` behavior while addressing the synchronous SDK startup path.

Google recommends background initialization: https://developers.google.com/admob/android/optimize-initialization

Validation:
- Android `testDebugUnitTest --tests 'com.getcapacitor.community.admob.AdMobTest*'`: 6 tests passed, including deferred execution, SDK completion ordering, UI dispatch, and error paths.
- Prettier checks passed for both changed Java files; `git diff --check` passed.
- Equivalent backport to 8.1.0 compiled successfully in a Capacitor Android consumer (`assembleDebug`); existing ad-event, retry, and consent regression checks passed.

Real-device startup/ad QA and a post-release ANR comparison remain pending. These tests do not establish a reduction in production ANRs or resolve other `nativePollOnce` clusters.
